### PR TITLE
Fix onboarding firmware-check: kind mismatch broke every real result

### DIFF
--- a/app/phone-ui/onboarding-firmware-check-view-model.ts
+++ b/app/phone-ui/onboarding-firmware-check-view-model.ts
@@ -7,7 +7,7 @@ import {
   hasExtractedEvenHubFonts,
   type FirmwareProgress,
 } from "../g2/firmware-builder";
-import { classifyOnboardingFirmware, FLASHABLE_STOCK_VERSION_TEXT } from "../g2/firmware-compat";
+import { classifyOnboardingFirmware, FLASHABLE_STOCK_VERSION_TEXT, type OnboardingFirmwareKind } from "../g2/firmware-compat";
 import { DeviceInfoProbe, DeviceInfoState } from "../native/device-info-probe";
 import { setOnboardingCompleted, setPreviewOnlyMode } from "./onboarding-state";
 import { formatErrorMessage } from "../util/format-error";
@@ -193,8 +193,16 @@ export class OnboardingFirmwareCheckViewModel extends Observable {
     }
   }
 
-  private applyClassification(kind: string, version: string, capabilities: string): void {
+  private applyClassification(kind: OnboardingFirmwareKind, version: string, capabilities: string): void {
     this.busy = false;
+    // `kind` is classifyOnboardingFirmware's OnboardingFirmwareKind ("custom" |
+    // "flashable-stock" | "newer-stock" | "unknown") -- NOT CheckPhase's shorter
+    // "flashable"/"newer" (used below via setPhase for _phase/primaryLabel/etc).
+    // The two types share two of four names, so a typo'd case label here type-checks
+    // fine as long as `kind` stays plain `string`, but silently falls through to
+    // `default` (the hard "couldn't read a firmware version" error) for every real
+    // stock-firmware version, flashable or newer alike -- onboarding was unusable for
+    // any device that ever reached this switch with an actual reported version.
     switch (kind) {
       case "custom":
         if (!hasExtractedEvenHubFonts()) {
@@ -203,14 +211,14 @@ export class OnboardingFirmwareCheckViewModel extends Observable {
         }
         this.showCustomReady(version, capabilities, false);
         break;
-      case "flashable":
+      case "flashable-stock":
         this.setPhase("flashable");
         this.headline = "Ready to Install";
         this.status =
           `Your glasses run stock firmware ${version}. This is compatible — tap Install Firmware to flash ` +
           "Faceclaw's custom firmware.";
         break;
-      case "newer":
+      case "newer-stock":
         this.setPhase("newer");
         this.headline = "Unrecognized Firmware";
         this.status =


### PR DESCRIPTION
## What

`OnboardingFirmwareCheckViewModel.applyClassification()`'s switch statement checked
`kind` against `"flashable"` / `"newer"`, but `classifyOnboardingFirmware()` (in
`firmware-compat.ts`) actually returns `"flashable-stock"` / `"newer-stock"` (see
`OnboardingFirmwareKind`). The two names it borrowed from `CheckPhase` (used a few
lines later via `setPhase()`) happen to share two of four values with
`OnboardingFirmwareKind`, so the mismatch type-checked fine as long as `kind` stayed
a plain `string`.

## Effect

Any device that successfully reported a firmware version — stock, `flashable-stock`,
or `newer-stock` alike — fell through to the `default` case and showed *"Connected,
but couldn't read a firmware version"*, the hard-block message meant for when the
probe gets no data at all. Only the `"custom"` case (name matches in both types)
ever worked correctly.

Found and confirmed on real hardware: glasses reporting stock firmware `2.2.9.22`.
The BLE probe read and logged the version correctly every single time
(`device-info: L=2.2.9.22 R=2.2.9.22 caps=[]`), but onboarding still reported it as
unreadable — a 100% reproducible dead end for onboarding on any firmware newer than
`2.2.6.10`.

## Fix

- Match the real `OnboardingFirmwareKind` strings in the switch.
- Tighten `applyClassification`'s `kind` parameter from `string` to
  `OnboardingFirmwareKind`, so this category of case-label typo fails to compile
  instead of failing silently.

## Testing

- `tsc --noEmit` clean.
- Verified live: onboarding now correctly reaches the "Unrecognized Firmware /
  Proceed Anyway" screen for stock `2.2.9.22`, instead of the false hard-block error.
