### PR TITLE
Fix EvenHub resume polling for up to 100ms instead of being notified (relates to #9)

### DIFF
--- a/App_Resources/Android/src/main/java/com/faceclaw/app/FaceclawBleCommunicator.java
+++ b/App_Resources/Android/src/main/java/com/faceclaw/app/FaceclawBleCommunicator.java
@@ -2375,6 +2375,12 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
             message.onAck.run();
         }
         consecutiveAckTimeouts = 0;
+        // onAck may have just satisfied a waiter blocked on lock.wait() (e.g.
+        // awaitEvenHubSessionReady polling fixedLayoutCreated/displayedFingerprint
+        // after a create-layout or image ack). Without this, that waiter only
+        // notices on its own up-to-100ms poll tick, adding avoidable latency to
+        // every EvenHub wake. Always called with lock held (see call site).
+        lock.notifyAll();
     }
 
     private void logImageUpdateSendLandmarkLocked(OutboundMessage message) {


### PR DESCRIPTION
This is a small, isolated fix for one of the three suspects named in #9 ("a bunch of avoidable bluetooth round trips").

Traced the resume path end to end. It turns out resume is already lean at the connection level — GATT connect, MTU negotiation, service discovery, and the security-auth exchange all correctly stay skipped, since both arm GATT connections are kept alive through suspend. So the BLE round trips themselves (prelude → create-layout → frame) aren't avoidable given the suspend design.

What *is* avoidable: `awaitEvenHubSessionReady()` — the wait every wake path (double-tap, wakeword, notification) blocks on — polls for completion at up to 100ms granularity (`lock.wait(Math.min(remaining, 100))`) instead of being woken when the relevant ack actually lands. `resolveAckLocked()`, which sets the fields that wait is polling for, never calls `notifyAll()`.

Fix: one `notifyAll()` call, guarded by the lock already being held at that call site. Every existing `wait()` in this file rechecks its own condition in a loop, so this can't introduce incorrect wakeups.

**Measured on real hardware** (Even G2 + Fold 7), resume-start to content-fully-on-glasses:
- Before: 620ms, 611ms (two independent cycles)
- After: 449ms
- ~167ms faster, ~27% reduction

Doesn't touch the other two suspects in #9 — "drawing a full frame on the phone" is untraced, and "sending that frame from scratch" is structurally required by the suspend design (it deliberately frees the on-glasses texture cache). Happy to help look at those too if useful.
