### PR TITLE
R1 ring health-data protocol, and a health layer over it (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ faceclaw_settings.xml
 # Developer configs
 build_paths.sh
 
+
+# tools/health-preview.cjs output (rendered PNGs, regenerate with the tool)
+preview/

--- a/App_Resources/Android/src/main/java/com/faceclaw/app/FaceclawBleCommunicator.java
+++ b/App_Resources/Android/src/main/java/com/faceclaw/app/FaceclawBleCommunicator.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 @SuppressLint("MissingPermission")
 public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
@@ -45,6 +46,13 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
     private static final long CFW_CLEANUP_WAIT_MS = 4_000;
     private static final int COMPASS_REPORT_INTERVAL_MS = 100;
     private static final int COMPASS_MIN_CHANGE_DEGREES = 0;
+
+    /**
+     * Cap on decoded ring health pages held in memory. A full backlog sync is
+     * ~40 pages, so this holds several syncs; oldest is dropped first. This is a
+     * holding area for a later health feature, not storage.
+     */
+    private static final int RING_HEALTH_MAX_RECORDS = 256;
 
     private final Context appContext;
     private final PowerManager powerManager;
@@ -92,6 +100,74 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
     private boolean leftConnected;
     private boolean ringConnected;
     private boolean ringNotificationsReady;
+    // R1 health-data protocol (RingProtocol). The reassembler and the outbound
+    // queue are both guarded by `lock`. Page ACKs are queued rather than written
+    // inline because notifications arrive on the GATT callback thread and
+    // bleManager.writeFrames() blocks waiting for onCharacteristicWrite, which
+    // that same thread has to deliver — writing there would deadlock until the
+    // write timeout. The worker loop drains the queue instead.
+    private final RingProtocol.Reassembler ringReassembler = new RingProtocol.Reassembler();
+    private final ArrayDeque<byte[]> ringOutbound = new ArrayDeque<>();
+    private final List<RingProtocol.HealthRecord> ringHealthRecords = new ArrayList<>();
+    /**
+     * Total records ever appended to {@link #ringHealthRecords}, including every
+     * one already consumed or evicted. Never reset.
+     *
+     * <p>This is the identity behind the ingest watermark. Record N is the Nth
+     * ever decoded this session, so a consumer that has durably stored
+     * everything below some N can ask for exactly that much to be dropped
+     * without racing the pages still arriving above it - see
+     * {@link #takeRingHealthBatch()} and
+     * {@link #clearRingHealthRecordsBelow(long)}. A plain "clear the list"
+     * could not do that: a page landing between the read and the clear would be
+     * thrown away having never been ingested. Guarded by {@code lock}.
+     */
+    private long ringHealthTotalAdded;
+    /**
+     * The phone-side sequence counter. One counter shared by BOTH ring channels
+     * (measured: 78 phone-to-ring writes in the reference capture step by
+     * exactly +1 regardless of channel, restarting at 1 on a new connection).
+     */
+    private int ringSeq;
+    private int ringNonce;
+    /**
+     * Response-driven health-pull state (2026-09-11). Set from
+     * {@link #handleRingHealthNotification} (GATT callback thread), waited on
+     * from {@link #requestRingHealth} (worker thread), both guarded by
+     * {@code lock}. Replaces a blind fixed-sleep loop - see that method's
+     * own doc for why: a real successful Even sync (extracted from
+     * {@code /tmp/btsnoop_fresh.log} on bazzite-desktop, 2026-09-11) is
+     * response-paced, not sleep-paced, and ACKs each DATA page immediately
+     * rather than after the whole run.
+     */
+    private boolean ringHealthRspSeen;
+    /** Bumped once per decoded health DATA page (any type) so a waiter can
+     * detect "a page just arrived" without polling ringHealthRecords. */
+    private int ringHealthPageCounter;
+    /**
+     * elapsedRealtime() of the last time {@link #requestRingHealth()} was
+     * attempted, or 0 if never. Health data updates hourly at the source
+     * (heart rate/HRV/SpO2) or slower, but a ring reconnect can happen far
+     * more often than that (BLE drops, Doze, app restarts - this evening's
+     * own live testing saw reconnects every few seconds under load). Pulling
+     * on every reconnect would be pure waste even ignoring the risk below;
+     * given the race condition documented on requestRingHealth() - a request
+     * that loses its race may silently discard real backlog rather than just
+     * delay it - it is actively worse than waste, so this is throttled.
+     */
+    private long ringHealthLastRequestedAtMs;
+    /**
+     * Set by {@link #requestRingHealthNow()} from whatever thread the UI is on;
+     * cleared by the worker loop, which is the only thread allowed to run the
+     * pull. Guarded by {@code lock}.
+     */
+    private boolean ringHealthPullRequested;
+    /**
+     * Aborted-pull retries spent since the last pull that COMPLETED its
+     * sequence. Guarded by {@code lock}. See
+     * {@link #RING_HEALTH_ABORTED_RETRY_LIMIT}.
+     */
+    private int ringHealthAbortedRetries;
     private boolean sessionReady;
     private boolean fixedLayoutCreated;
     private boolean shutdownRequested;
@@ -1629,6 +1705,19 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
                     continue;
                 }
 
+                // Page ACKs queued from the GATT callback thread are written
+                // here, on the only thread allowed to block on a GATT write.
+                flushRingOutbound();
+
+                // An on-demand pull asked for from the UI thread runs here for
+                // the same reason: requestRingHealth() blocks on GATT writes and
+                // on its own RSP/DATA waits, which only this thread may do.
+                runRequestedRingHealthPull();
+                // An aborted pull is unfinished business, not a speculative
+                // repeat - see RING_HEALTH_ABORTED_RETRY_LIMIT. Cheap: returns
+                // immediately unless a pull actually failed to complete.
+                resumeAbortedRingHealthPull();
+
                 long sleepMs = driveSession();
                 if (sleepMs > 0) {
                     interruptibleSleep.sleep(sleepMs);
@@ -1860,6 +1949,9 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
     }
 
     private void handleDirectRingNotification(String characteristicUuid, byte[] data) {
+        if (handleRingHealthNotification(characteristicUuid, data)) {
+            return;
+        }
         FaceclawRingEventDecoder.DirectRingEvent decoded = FaceclawRingEventDecoder.decode(data);
         if (decoded == null) {
             Log.d(TAG, "direct ring notify ignored: characteristicUuid=" + characteristicUuid + " raw=" + hex(data));
@@ -1876,6 +1968,133 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
         int frameId = FrameTimings.getInstance().startFrame("input:ring:" + decoded.label);
         FrameTimings.getInstance().log(frameId, "input event decoded from direct ring notification");
         emitRingEvent(event.kind, event.containerName, event.eventType, event.eventSource, event.systemExitReasonCode, frameId);
+        interruptibleSleep.interrupt();
+    }
+
+    /**
+     * The R1 health-data protocol branch. Returns true when the value belonged
+     * to that protocol and must not fall through to the gesture decoder.
+     *
+     * <p>Runs on the GATT callback thread, so it only ever queues writes.
+     *
+     * <p>Restricted to R1_NOTIFY_CHAR_UUID because that is the notify
+     * characteristic (ATT handle 0x0017) the reference capture shows this
+     * protocol on; gesture traffic on the other notify characteristic is left
+     * strictly alone rather than being offered to the reassembler.
+     */
+    private boolean handleRingHealthNotification(String characteristicUuid, byte[] data) {
+        if (!BleProtocol.R1_NOTIFY_CHAR_UUID.equals(characteristicUuid)) {
+            return false;
+        }
+
+        RingProtocol.Intake intake;
+        synchronized (lock) {
+            intake = ringReassembler.accept(data);
+        }
+        if (!intake.consumed) {
+            return false;
+        }
+
+        long arrivalMs = SystemClock.elapsedRealtime();
+        synchronized (lock) {
+            lastIncomingAtMs = arrivalMs;
+        }
+        if (intake.note != null) {
+            logLine("ring frame: " + intake.note);
+        }
+        RingProtocol.Frame frame = intake.frame;
+        if (frame == null) {
+            // Genuinely silent by default: the reassembler consumed these
+            // bytes (e.g. as a fragment awaiting its continuation) without
+            // yet producing a complete frame, and intake.note was null too.
+            // This exact blind spot cost real debugging time on 2026-09-10 -
+            // DATA appeared to simply never arrive, when the actual cause
+            // (once found, by temporarily logging every raw notification
+            // unconditionally) was a real handshake gap, not a dropped
+            // frame here. If DATA ever looks like it's going missing again
+            // with nothing logged at all, re-add that raw hex dump here
+            // rather than assuming nothing arrived on the wire.
+            logLine("ring frame: consumed, no complete frame yet, len=" + data.length);
+            return true;
+        }
+        if (!frame.crcOk) {
+            // Never act on a frame whose CRC failed: the payload offsets below
+            // are only meaningful for an intact frame.
+            logLine("ring frame CRC mismatch " + frame.describe());
+            return true;
+        }
+
+        // Route on the CHAN byte, not on the shape of the payload.
+        if (frame.chan != RingProtocol.CHAN_HEALTH) {
+            Log.d(TAG, "ring device frame " + frame.describe());
+            return true;
+        }
+
+        if (frame.kind == RingProtocol.KIND_RSP) {
+            Log.d(TAG, "ring health rsp " + frame.describe());
+            synchronized (lock) {
+                ringHealthRspSeen = true;
+                lock.notifyAll();
+            }
+            return true;
+        }
+        if (frame.kind != RingProtocol.KIND_DATA) {
+            Log.d(TAG, "ring health frame " + frame.describe());
+            return true;
+        }
+
+        RingProtocol.HealthRecord record = null;
+        try {
+            record = RingProtocol.decode(frame, System.currentTimeMillis());
+        } catch (Throwable t) {
+            logLine("ring health decode error " + frame.describe() + ": " + safeMessage(t));
+        }
+        if (record == null) {
+            logLine("ring health page undecoded " + frame.describe());
+        } else {
+            synchronized (lock) {
+                if (ringHealthRecords.size() >= RING_HEALTH_MAX_RECORDS) {
+                    // This was silent. An eviction here drops a record that
+                    // nothing has ingested yet - real data lost inside the
+                    // phone, with no trace anywhere. Say so. With the consume
+                    // path in place the buffer should never reach this size;
+                    // if this line ever appears, the consumer has stopped.
+                    logLine("ring health: buffer FULL at " + RING_HEALTH_MAX_RECORDS
+                        + " - dropping the oldest UNINGESTED record");
+                    ringHealthRecords.remove(0);
+                }
+                ringHealthRecords.add(record);
+                ringHealthTotalAdded++;
+            }
+            logLine("ring health " + record.summary());
+        }
+
+        // Acknowledge the page regardless of whether we could decode it: the
+        // ACK is what keeps the ring sending, and a decode gap must not stall
+        // the rest of the transfer.
+        queueRingPageAck(frame);
+        return true;
+    }
+
+    private void queueRingPageAck(RingProtocol.Frame page) {
+        byte[] ack;
+        synchronized (lock) {
+            if (!ringNotificationsReady) {
+                return;
+            }
+            ack = RingProtocol.buildPageAck(
+                nextRingSeqLocked(),
+                nextRingNonceLocked(),
+                page.cmdHi,
+                page.cmdLo,
+                page.seq
+            );
+            ringOutbound.add(ack);
+            ringHealthPageCounter++;
+            lock.notifyAll();
+        }
+        // The worker loop does the actual write; wake it so the ACK is not held
+        // for a whole idle tick.
         interruptibleSleep.interrupt();
     }
 
@@ -1907,6 +2126,10 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
                 ringNotificationsReady = false;
                 if (!connected) {
                     ringReconnectAfterMs = SystemClock.elapsedRealtime() + ConnectionOptions.RING_RECONNECT_DELAY_MS;
+                    // Half-received fragments and unsent ACKs do not survive the
+                    // link; the sequence counter restarts on the next connect.
+                    ringReassembler.reset();
+                    ringOutbound.clear();
                 }
                 logLine(connected ? "direct ring BLE connected" : "direct ring BLE disconnected");
                 return;
@@ -2092,17 +2315,43 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
 
     private void connectRing() {
         logLine("connecting direct ring " + ringAddress);
-        if (!bleManager.connect(ringAddress, ConnectionOptions.CONNECT_TIMEOUT_MS)) {
+        // autoConnect=true (see FaceclawBleManager.connect's 3-arg overload) -
+        // matches what Even's own app does for this device specifically.
+        // Direct connect (false, the default used for the glasses) was
+        // measured tonight dying ~5s into an otherwise-idle ring connection,
+        // repeatedly, with nothing else competing for it.
+        if (!bleManager.connect(ringAddress, ConnectionOptions.RING_CONNECT_TIMEOUT_MS, true)) {
             throw new IllegalStateException("connect failed: " + ringAddress);
         }
 
-        bleManager.requestConnectionPriority(ringAddress, BluetoothGatt.CONNECTION_PRIORITY_HIGH);
+        // Deliberately NOT requesting CONNECTION_PRIORITY_HIGH here (2026-09-11).
+        // Even's own app never requests any priority for the ring at all - it
+        // logs no requestConnectionPriority/onConnectionUpdated call anywhere -
+        // and just runs on whatever Android's default (BALANCED) parameters are.
+        // HIGH negotiated interval=12 (15ms) / timeout=500 (5000ms) here, and a
+        // live test tonight found the ring-only connection reliably dying at
+        // 5.5-5.7s, matching that 5000ms supervision timeout almost exactly,
+        // on every attempt, with nothing else competing for the ring. If the
+        // ring's firmware occasionally needs more than 5s of headroom after a
+        // burst of writes, HIGH priority's short timeout would kill the link
+        // while Even's default (longer) one wouldn't - untested but the timing
+        // match is exact, not approximate. Leaving default priority for the
+        // ring only; the glasses' own HIGH-priority request above is untouched.
         bleManager.requestMtu(ringAddress, ConnectionOptions.RING_DESIRED_MTU, ConnectionOptions.CONNECT_TIMEOUT_MS);
 
         if (!bleManager.discoverServices(ringAddress, ConnectionOptions.SERVICES_TIMEOUT_MS)) {
             throw new IllegalStateException("discoverServices failed: " + ringAddress);
         }
 
+        // Even's app subscribes only to the health-data notify CCCD (ATT
+        // handle 24) and never touches the phone-notify one (handle 19). That
+        // difference was briefly suspected on 2026-09-11 of causing the ring's
+        // total silence and this call was dropped to match - it changed
+        // nothing, and the real cause turned out to be the malformed 00:08
+        // frame (see sendRingHandshake). Restored, because the phone-notify
+        // channel is plausibly what carries ring-as-remote gesture events,
+        // which are a daily-driver feature; matching Even byte-for-byte here
+        // buys nothing and risks breaking them.
         boolean phoneNotify = enableRingNotification(BleProtocol.R1_PHONE_NOTIFY_CHAR_UUID);
         boolean dataNotify = enableRingNotification(BleProtocol.R1_NOTIFY_CHAR_UUID);
         if (!phoneNotify && !dataNotify) {
@@ -2113,8 +2362,776 @@ public class FaceclawBleCommunicator implements FaceclawBleListener, Runnable {
             ringConnected = true;
             ringNotificationsReady = true;
             ringReconnectAfterMs = 0;
+            // The ring's sequence counter restarts with the connection.
+            ringSeq = 0;
+            ringNonce = 0;
+            ringReassembler.reset();
+            ringOutbound.clear();
         }
         logLine("direct ring ready phoneNotify=" + phoneNotify + " dataNotify=" + dataNotify);
+
+        if (dataNotify) {
+            // The handshake mirrors what Even's own app repeats on every one
+            // of its sync bursts (confirmed in the reference capture), so
+            // sending it on every reconnect matches known-working behavior.
+            // The actual health pull is throttled separately below - see
+            // ringHealthLastRequestedAtMs and requestRingHealth()'s own
+            // race-condition warning for why.
+            sendRingHandshake();
+            long now = SystemClock.elapsedRealtime();
+            boolean dueForHealthPull;
+            synchronized (lock) {
+                dueForHealthPull = ringHealthPullDueLocked(now);
+                if (dueForHealthPull) {
+                    ringHealthLastRequestedAtMs = now;
+                }
+            }
+            if (dueForHealthPull) {
+                runRingHealthPull();
+            } else {
+                logLine("ring health: pull skipped, last one was "
+                    + ((now - ringHealthLastRequestedAtMs) / 1000) + "s ago");
+            }
+        }
+    }
+
+    /**
+     * Floor between health pulls, independent of how often the ring
+     * reconnects. Heart rate/HRV/SpO2 update hourly at the source and steps
+     * every 10 minutes (confirmed from the real export,
+     * {@code knowledge/inbox/Even_health_data/}); 30 minutes is comfortably
+     * inside that cadence while keeping reconnect churn from turning into
+     * repeated pull attempts against the race condition documented on
+     * {@link #requestRingHealth()}. Not tuned against any real constraint
+     * from the ring itself - just a sane default.
+     *
+     * <p><b>Reduced 30min -> 5min on 2026-09-12, and its JOB CHANGED.</b> The
+     * 30-minute figure was always meant as a CADENCE - how often to collect -
+     * but it was implemented here as a floor, which is a different thing. The
+     * result was that a connected, stable ring pulled <em>never</em>: nothing
+     * drives a pull on a timer, only {@code onRingReady()} on reconnect, so the
+     * floor was the only clock in the system and it gated a pull that had
+     * nothing to trigger it.
+     *
+     * <p>The cadence now lives where it belongs, on a wall-clock-aligned tick
+     * (:01 and :31) in {@code health-live.ts}. What remains here is purely an
+     * ANTI-SPAM floor: stop a burst of reconnects turning into a burst of
+     * requests against the race documented on {@link #requestRingHealth()}.
+     * That job needs 5 minutes, not 30.
+     */
+    private static final long RING_HEALTH_MIN_PULL_INTERVAL_MS = 5L * 60L * 1000L;
+
+    /**
+     * Floor for a pull the user actually asked for by opening the health app,
+     * as opposed to the automatic one above.
+     *
+     * <p>Deliberately much shorter than the automatic interval but <b>not
+     * zero</b>. The 30-minute figure is conservative because an automatic pull
+     * is speculative — nobody is waiting for it, so there is no reason to spend
+     * a request. Opening the health app is the opposite: it is an explicit ask,
+     * and the response-driven {@link #requestRingHealth()} now waits for each
+     * type's DATA and ACKs its pages before advancing, which is what made the
+     * backlog-discard race survivable in the first place. A floor still has to
+     * exist, because the discard risk documented on {@code requestRingHealth()}
+     * is real and open/close/open would otherwise hammer the ring.
+     */
+    private static final long RING_HEALTH_ON_DEMAND_MIN_INTERVAL_MS = 60L * 1000L;
+
+    /**
+     * How many times a pull that ABORTED may be resumed inside the anti-spam
+     * floor before it goes back to waiting that floor out.
+     *
+     * <p>The floor exists to stop SPECULATIVE repeat pulls, because a request
+     * that loses its race can permanently consume backlog - see
+     * {@link #requestRingHealth()}. Resuming a pull that never got a single
+     * answer is a different thing: nothing was ever in flight to be lost.
+     *
+     * <p>Measured 2026-09-12: the 09:33 pull got {@code no RSP} for 0x1, 0x4
+     * and 0x2 and then died on {@code write error: IllegalStateException: Not
+     * connected}. Every attempt after it was refused by the 30-minute floor, so
+     * the rest of that night's data was simply never requested again - the
+     * night's second sleep block went with it. The floor was protecting against
+     * the wrong thing.
+     *
+     * <p>Bounded and non-looping on purpose: the budget is spent whether or not
+     * the retries help, and a pull that completes resets it. Worst case is two
+     * extra attempts, then silence until the floor expires.
+     *
+     * <p>⚠ UNTESTED, and worth knowing before trusting this: whether an aborted
+     * pull's data is still on the ring at all, or was discarded when the ring
+     * RSP'd (it did not RSP here, which is the reason to think it survives).
+     * Nobody knows. The retry costs little if the data is gone.
+     */
+    private static final int RING_HEALTH_ABORTED_RETRY_LIMIT = 2;
+
+    /**
+     * Gap before an aborted pull may be resumed. Short, but not zero - a link
+     * that just failed a write needs time to come back, and a tight loop
+     * against a dead connection helps nobody.
+     */
+    private static final long RING_HEALTH_ABORTED_RETRY_GAP_MS = 60L * 1000L;
+
+    /**
+     * Ask for a health pull as soon as the worker thread can run one. Safe to
+     * call from any thread; returns immediately without blocking.
+     *
+     * <p>Called when the health app opens, so a glance shows something current
+     * rather than whatever the last automatic pull happened to catch. Subject
+     * to {@link #RING_HEALTH_ON_DEMAND_MIN_INTERVAL_MS}; a request inside that
+     * window is dropped rather than queued, because a stale duplicate pull has
+     * no value and every pull carries the discard risk.
+     */
+    public void requestRingHealthNow() {
+        synchronized (lock) {
+            ringHealthPullRequested = true;
+        }
+        interruptibleSleep.interrupt();
+    }
+
+    /**
+     * Whether an automatic pull may run now. Caller must hold {@code lock}.
+     *
+     * <p>Two ways to be due: the ordinary 30-minute floor has expired, or the
+     * last pull ABORTED and still has retry budget. The second is not a
+     * speculative repeat - see {@link #RING_HEALTH_ABORTED_RETRY_LIMIT}.
+     */
+    private boolean ringHealthPullDueLocked(long now) {
+        if (ringHealthLastRequestedAtMs == 0) {
+            return true;
+        }
+        long since = now - ringHealthLastRequestedAtMs;
+        if (since >= RING_HEALTH_MIN_PULL_INTERVAL_MS) {
+            return true;
+        }
+        return ringHealthAbortedRetries > 0 && since >= RING_HEALTH_ABORTED_RETRY_GAP_MS;
+    }
+
+    /**
+     * Run a pull and account for whether it finished. The ONLY place
+     * {@link #requestRingHealth()} may be called from, so that every path
+     * shares one definition of "aborted".
+     */
+    private void runRingHealthPull() {
+        boolean completed = requestRingHealth();
+        synchronized (lock) {
+            if (completed) {
+                ringHealthAbortedRetries = 0;
+            } else if (ringHealthAbortedRetries < RING_HEALTH_ABORTED_RETRY_LIMIT) {
+                ringHealthAbortedRetries++;
+                logLine("ring health: aborted pull may resume in "
+                    + (RING_HEALTH_ABORTED_RETRY_GAP_MS / 1000L) + "s (retry "
+                    + ringHealthAbortedRetries + "/" + RING_HEALTH_ABORTED_RETRY_LIMIT + ")");
+            } else {
+                ringHealthAbortedRetries = 0;
+                logLine("ring health: aborted pull retry budget spent, back to the "
+                    + (RING_HEALTH_MIN_PULL_INTERVAL_MS / 60000L) + "-minute anti-spam floor");
+            }
+        }
+    }
+
+    /**
+     * Worker-thread tick that resumes a pull which ABORTED.
+     *
+     * <p>Distinct from {@link #runRequestedRingHealthPull()}: nobody asked for
+     * this one. It exists because the automatic pull otherwise only fires from
+     * the ring-ready path, so an abort that is not followed by a reconnect
+     * would never be retried at all.
+     */
+    private void resumeAbortedRingHealthPull() {
+        long now = SystemClock.elapsedRealtime();
+        synchronized (lock) {
+            if (ringHealthAbortedRetries == 0) {
+                return;
+            }
+            if (!ringConnected || !ringNotificationsReady) {
+                return;
+            }
+            if (now - ringHealthLastRequestedAtMs < RING_HEALTH_ABORTED_RETRY_GAP_MS) {
+                return;
+            }
+            ringHealthLastRequestedAtMs = now;
+        }
+        logLine("ring health: resuming an aborted pull");
+        runRingHealthPull();
+    }
+
+    /** Worker-thread side of {@link #requestRingHealthNow()}. */
+    private void runRequestedRingHealthPull() {
+        long now = SystemClock.elapsedRealtime();
+        synchronized (lock) {
+            if (!ringHealthPullRequested) {
+                return;
+            }
+            ringHealthPullRequested = false;
+            if (!ringConnected || !ringNotificationsReady) {
+                logLine("ring health: on-demand pull skipped, ring not ready");
+                return;
+            }
+            if (ringHealthLastRequestedAtMs != 0
+                    && now - ringHealthLastRequestedAtMs < RING_HEALTH_ON_DEMAND_MIN_INTERVAL_MS) {
+                logLine("ring health: on-demand pull skipped, last one was "
+                    + ((now - ringHealthLastRequestedAtMs) / 1000) + "s ago");
+                return;
+            }
+            ringHealthLastRequestedAtMs = now;
+        }
+        logLine("ring health: on-demand pull requested");
+        runRingHealthPull();
+    }
+
+    /**
+     * Device-channel prelude the ring requires before it will answer any
+     * channel-0x02 (health) request. <b>Confirmed live, 2026-09-10: without
+     * this, the ring never responds at all to a bare health REQ - not even
+     * an RSP.</b> With it, RSPs start flowing immediately. The direct-ring
+     * path has no other handshake or auth step, so this is the whole gate.
+     *
+     * <p>These five frames were found by byte-for-byte comparison against a
+     * real Even-app sync (pkt 8814-9153 in the capture behind
+     * {@code knowledge/staging/faceclaw-ring-protocol-decode-return.md}),
+     * replayed here in the same order, right after the ring connects.
+     * <b>Which of the five is actually load-bearing is unknown</b> - all
+     * five go out together because that combination is the only one proven
+     * to work; nobody has yet tried removing any of them. Three of them
+     * (00:08, 06:02, 00:0A) carry payload bytes with no known meaning beyond
+     * "the ring accepted them from Even's app" - opaque constants, copied
+     * verbatim, not derived. Do not change them without new evidence.
+     *
+     * <p>The other two (00:0E clock-set, 00:05 day-anchor) need a live
+     * value: both carry the current Unix time offset by the local UTC offset,
+     * which in EDT is +14400s (4h) - and +14400s is what a real Even write
+     * carries. Verified 2026-09-11 against six separate real Even clock-set
+     * writes. As of 2026-09-12 the offset is COMPUTED from the device time
+     * zone rather than hardcoded, which is identical in EDT and stays correct
+     * across a DST change; see the comment in {@code sendRingHandshake()}.
+     *
+     * <p><b>Skew trap - read before "correcting" this number.</b> Earlier on
+     * 2026-09-11 this was changed to +28800s (8h) and that was wrong. The
+     * mistake: btsnoop packet timestamps on this phone run exactly 4 hours
+     * BEHIND the Android system clock (the system clock itself is correct -
+     * {@code adb shell date} agrees with real time). Measuring Even's sent
+     * value against the btsnoop timestamp therefore double-counts the 4h and
+     * makes a correct +14400 look like +28800. The skew is verified
+     * sub-second by lining btsnoop up against logcat on the same connect:
+     * logcat "direct ring BLE connected" 05:58:24.616 vs btsnoop MTU Req
+     * 01:58:24.618; "ring ready" .983 vs CCCD Write Rsp .981; "handshake
+     * sent" 25.085 vs first Write Command 25.071. Same milliseconds, hour
+     * off by four. <b>Always convert btsnoop timestamps to real local time
+     * (+4h) before comparing them to anything.</b>
+     *
+     * <p>A stale, yesterday's timestamp here was separately tested and ruled
+     * out as the reason DATA wasn't following RSP - but nothing says a stale
+     * value is harmless either, so this always sends the true current time.
+     */
+    /**
+     * Round 2 (2026-09-11, ~00:55 EDT): compared this handshake against a
+     * fresh HCI-snoop capture of Even's own app completing a real successful
+     * sync minutes earlier. Two real findings from that comparison:
+     * - The 00:0A payload (the "app identity?" blob) is byte-for-byte
+     *   identical between that capture and one from two nights before - a
+     *   true fixed constant, not a rotating per-session token. Rules out the
+     *   "stale identity token" theory tried first.
+     * - Even's real sequence also sends battery (00:01), firmware version
+     *   (00:02), and device id (00:0B) - none of which round 1 ever sent -
+     *   interleaved with the health requests, not just once upfront. Notably
+     *   the firmware-version query lands immediately before Even's own first
+     *   successful health request in the real trace. `06:02`, which round 1
+     *   did send, never appears anywhere in that real successful sync -
+     *   dropped here since there's now real evidence it isn't needed and it
+     *   was never more than a guess to begin with.
+     * This round adds 00:01/00:02/00:0B up front rather than interleaved
+     * (interleaving would need restructuring requestRingHealth() too - a
+     * bigger change deferred until this simpler version is shown to help or
+     * not).
+     */
+    private void sendRingHandshake() {
+        // +14400s was hardcoded here because every capture behind this work was
+        // taken in EDT, where 14400s happens to be the magnitude of the UTC
+        // offset - so the constant was right by coincidence of season, not by
+        // derivation, and would have gone an hour wrong at the next DST change.
+        // This computes it instead: identical in EDT, correct year-round.
+        //
+        // ⚠ MIND THE SIGN. The ring's clock runs AHEAD of real time by the
+        // magnitude of a west-of-UTC offset, so the quantity wanted here is
+        // NEGATIVE `TimeZone.getOffset()`, which is itself negative west of UTC
+        // (-14400000ms in EDT). Getting this backwards sets the ring's clock 8h
+        // wrong rather than 0h wrong. Measured 2026-09-12: the un-negated form
+        // logged -14400 and the ring then returned step buckets dated 8h out.
+        //
+        // Note this is the OPPOSITE of the "ring stores naive local time"
+        // hypothesis, which predicts `epoch + utc_offset` = epoch - 14400. The
+        // measured, working value is epoch + 14400. The hypothesis is therefore
+        // NOT confirmed by this code; what is preserved here is the behaviour
+        // verified against six real Even clock-set writes.
+        //
+        // ⚠ PAIRED with `ringClockOffsetMs()` in `app/health/health-live.ts`,
+        // which subtracts the same quantity on the way back out. These two must
+        // move together; both now compute the value rather than hardcoding EDT.
+        long nowMs = System.currentTimeMillis();
+        long clockOffsetSeconds = -TimeZone.getDefault().getOffset(nowMs) / 1000L;
+        long liveClockSeconds = (nowMs / 1000L) + clockOffsetSeconds;
+        // Asserted at every handshake: in EDT this must read 14400. The clock write
+        // is the part of this protocol that took two sessions to get working, so a
+        // changed value here is the one way a working pull silently breaks.
+        Log.i(TAG, "ring handshake clock offset seconds = " + clockOffsetSeconds
+                + " (tz " + TimeZone.getDefault().getID() + ")");
+        byte[] clock = le32(liveClockSeconds);
+
+        int seq1, nonce1, seq2, nonce2, seq3, nonce3, seq4, nonce4, seq5, nonce5, seq6, nonce6, seq7, nonce7;
+        synchronized (lock) {
+            seq1 = nextRingSeqLocked();
+            nonce1 = nextRingNonceLocked();
+            seq2 = nextRingSeqLocked();
+            nonce2 = nextRingNonceLocked();
+            seq3 = nextRingSeqLocked();
+            nonce3 = nextRingNonceLocked();
+            seq4 = nextRingSeqLocked();
+            nonce4 = nextRingNonceLocked();
+            seq5 = nextRingSeqLocked();
+            nonce5 = nextRingNonceLocked();
+            seq6 = nextRingSeqLocked();
+            nonce6 = nextRingNonceLocked();
+            seq7 = nextRingSeqLocked();
+            nonce7 = nextRingNonceLocked();
+        }
+
+        byte[][] frames = {
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_REQ, 0x00, 0x08, seq1,
+                // NO nonce prefix on this one frame - payload is exactly the
+                // three bytes 3f 01 01. Every other request on both channels
+                // starts with the 2-byte nonce; 00:08 does not, and the ring
+                // silently drops the whole frame if you add one, then ignores
+                // everything that follows on the connection.
+                //
+                // Measured 2026-09-11 across all four btsnoop captures, 46
+                // real 00:08 writes, zero exceptions:
+                //   payload 3f0101       (3 bytes) -> 3 writes, ALL answered (12-21 notifications each)
+                //   payload 01003f0101   (5 bytes) -> 43 writes, ALL silent (zero notifications)
+                // The 5-byte form is the more common one in the captures only
+                // because it is ours, failing and retrying all night. Do not
+                // "fix" this back to the nonce form by pattern-matching the
+                // other frames or by counting which variant appears more.
+                //
+                // This also explains 2026-09-10: the handshake worked when it
+                // was raw bytes replayed from the capture, and stopped working
+                // the moment it was rebuilt "properly" through buildFrame(),
+                // which is what introduced the nonce prefix.
+                new byte[] {0x3f, 0x01, 0x01}),
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_DATA, 0x00, 0x0e, seq2,
+                concatBytes(le16(nonce2), clock, new byte[] {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_DATA, 0x00, 0x05, seq3,
+                concatBytes(le16(nonce3), new byte[] {0x10, (byte) 0xff}, clock)),
+            // Battery, firmware version, device id - all bare nonce-only REQs,
+            // same shape as the health requests. New this round.
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_REQ, 0x00, 0x01, seq4,
+                le16(nonce4)),
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_REQ, 0x00, 0x02, seq5,
+                le16(nonce5)),
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_REQ, 0x00, 0x0b, seq6,
+                le16(nonce6)),
+            RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_REQ, 0x00, 0x0a, seq7,
+                concatBytes(le16(nonce7), parseHex("f8f53d235ac4ceaa073885cc"))),
+        };
+        for (byte[] frame : frames) {
+            if (!writeRingFrame(frame, "handshake")) {
+                return;
+            }
+        }
+        logLine("ring health: sent device-channel handshake (" + frames.length + " frames)");
+    }
+
+    private static byte[] parseHex(String hex) {
+        byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
+
+    private static byte[] le16(int value) {
+        return new byte[] {(byte) value, (byte) (value >>> 8)};
+    }
+
+    private static byte[] le32(long value) {
+        return new byte[] {(byte) value, (byte) (value >>> 8), (byte) (value >>> 16), (byte) (value >>> 24)};
+    }
+
+    private static byte[] concatBytes(byte[]... parts) {
+        int len = 0;
+        for (byte[] part : parts) {
+            len += part.length;
+        }
+        byte[] out = new byte[len];
+        int offset = 0;
+        for (byte[] part : parts) {
+            System.arraycopy(part, 0, out, offset, part.length);
+            offset += part.length;
+        }
+        return out;
+    }
+
+    /**
+     * Timeout waiting for a health REQ's own RSP. In the reference capture
+     * (a real successful Even sync, extracted from
+     * {@code /tmp/btsnoop_fresh.log} on bazzite-desktop, 2026-09-11) RSPs
+     * land within ~150ms; this only needs to bound the pathological "ring
+     * stopped answering entirely" case.
+     */
+    private static final long RING_HEALTH_RSP_TIMEOUT_MS = 3000L;
+
+    /**
+     * How long to keep waiting after the most recent DATA page for a health
+     * type before deciding its transfer is over (or that there was never
+     * going to be one). Chosen from the same reference capture: consecutive
+     * pages for one type land well under a second apart, so 1.5s covers
+     * that with real margin while still moving on quickly when a type
+     * genuinely has nothing new.
+     */
+    private static final long RING_HEALTH_DATA_IDLE_MS = 1500L;
+
+    /**
+     * Device-channel commands Even's real app fires in the gaps between
+     * health requests - identity (0x0a), battery (0x01), firmware version
+     * (0x02), device id (0x0b) - found by extracting the literal wire order
+     * of a real successful sync (same capture as above; two independent
+     * syncs in it agree). Rotated one-per-health-type here rather than
+     * replicated exactly (Even's real cadence isn't perfectly regular
+     * either - compare the two syncs in the capture), since which of these,
+     * if any, is actually load-bearing for the ring answering has never
+     * been isolated. This is matching cadence, not a confirmed protocol
+     * requirement.
+     */
+    private static final int[] RING_DEVICE_PING_CMD_LO = {0x0a, 0x01, 0x02, 0x0b};
+
+    /**
+     * Pull the five health record types. Each request is a bare 17-byte frame
+     * carrying only a nonce; the ring answers with an RSP on the same
+     * sequence number, then - sometimes - pushes one or more DATA pages,
+     * which arrive through {@link #handleRingHealthNotification}.
+     *
+     * <p><b>Response-driven, not sleep-driven (rewritten 2026-09-11).</b>
+     * The original version fired all five REQs on a blind fixed sleep and
+     * only flushed queued page ACKs after the whole loop finished - a real
+     * successful Even sync (see the constants above) does the opposite: it
+     * waits for each REQ's own RSP, waits for DATA to go idle, ACKs
+     * immediately, then interleaves one device-channel command before the
+     * next health type. This version does the same, using the existing
+     * lock.wait()/notifyAll() idiom already used elsewhere in this class
+     * (e.g. the shutdown-ack wait above) rather than a new mechanism.
+     *
+     * <p><b>Race condition, confirmed live 2026-09-10 - this is what the
+     * rewrite above addresses, not a reason to remove this warning.</b> The
+     * ring appears to hold only one health type's response in flight at a
+     * time. Sending the next health REQ before the previous type's DATA
+     * page(s) have actually arrived silently drops the earlier type's DATA:
+     * you still get its RSP, you never get its DATA, and nothing in the
+     * protocol signals an error. Evidence: five REQs fired back-to-back (the
+     * old blind-sleep version, badly timed) got five RSPs and zero DATA
+     * pages over more than a minute of waiting.
+     *
+     * <p><b>Worse: a lost race may PERMANENTLY discard that backlog, not
+     * just delay it.</b> On 2026-09-10, real HRV/SpO2/sleep backlog that
+     * should have existed (unreported since that morning, confirmed against
+     * the hourly export cadence in {@code knowledge/inbox/Even_health_data})
+     * did not come back on a later, more carefully spaced retry. The working
+     * theory - not proven, but treat it as true until disproven, because the
+     * downside of being wrong is silent data loss with nothing to catch it
+     * - is that the ring advances its own "last delivered" watermark for a
+     * type as soon as it RSPs a REQ for it, whether or not the DATA page
+     * actually made it out. <b>Do not send a speculative or test health REQ
+     * for a type unless you intend to actually receive and persist its
+     * DATA</b> - re-requesting will not recover what an earlier, raced
+     * request already consumed. The rewrite below waiting for DATA to go
+     * idle before advancing reduces how often this can happen but does not
+     * prove it can no longer happen (e.g. if the ring's real per-type
+     * timeout is shorter than RING_HEALTH_DATA_IDLE_MS for some type).
+     *
+     * <p>A separate, completely ordinary case looks identical from the wire
+     * alone: an RSP with no DATA can also just mean the ring genuinely has
+     * nothing new for that metric since the last successful pull. There is
+     * currently no way to tell "raced and silently discarded" apart from
+     * "genuinely nothing new" other than knowing independently whether fresh
+     * data should exist (e.g. from the export's own sampling cadence).
+     *
+     * <p>Runs on the worker thread (from connectRing), which is the only
+     * thread allowed to call the blocking write path - the wait loops below
+     * block that same thread, which is why {@link #flushRingOutbound} is
+     * called explicitly after each type rather than relying on the main
+     * loop's own call to it.
+     */
+    private boolean requestRingHealth() {
+        int[] commands = RingProtocol.HEALTH_COMMANDS;
+        int rspCount = 0;
+        for (int i = 0; i < commands.length; i++) {
+            int command = commands[i];
+            byte[] frame;
+            synchronized (lock) {
+                ringHealthRspSeen = false;
+                frame = RingProtocol.buildHealthRequest(command, nextRingSeqLocked(), nextRingNonceLocked());
+            }
+            if (!writeRingFrame(frame, "health request 0x" + Integer.toHexString(command))) {
+                // ABORTED: the sequence stopped partway. Distinct from "the
+                // ring had nothing for a type", which is an ordinary outcome
+                // and leaves the loop running - see the return below.
+                logLine("ring health: pull ABORTED on write at 0x" + Integer.toHexString(command)
+                    + " (" + i + " of " + commands.length + " types attempted, "
+                    + rspCount + " answered)");
+                return false;
+            }
+
+            if (awaitRingHealthRsp(RING_HEALTH_RSP_TIMEOUT_MS)) {
+                rspCount++;
+                awaitRingHealthDataIdle(RING_HEALTH_DATA_IDLE_MS);
+            } else {
+                logLine("ring health: no RSP for command 0x" + Integer.toHexString(command) + ", moving on");
+            }
+            // Write out any ACK(s) queued by DATA pages that just landed,
+            // right now rather than after the whole loop - this is the fix
+            // for the bug the doc above describes.
+            flushRingOutbound();
+
+            if (i < commands.length - 1) {
+                sendRingDevicePing(RING_DEVICE_PING_CMD_LO[i % RING_DEVICE_PING_CMD_LO.length]);
+            }
+        }
+
+        // Two more ways to have not really completed, both distinguishable from
+        // "completed but empty":
+        //
+        //   - the link dropped while the loop was running, so the later types
+        //     were written into nothing;
+        //   - the ring answered NONE of the five. A type with no backlog still
+        //     RSPs (measured: five REQs, five RSPs, zero DATA), so zero RSPs
+        //     across the whole sequence means the ring was not answering at
+        //     all, not that there was nothing to send.
+        //
+        // An RSP with no DATA remains ambiguous per type and is NOT treated as
+        // a failure here - that is the ordinary "nothing new" case.
+        boolean stillConnected;
+        synchronized (lock) {
+            stillConnected = ringConnected;
+        }
+        if (!stillConnected || rspCount == 0) {
+            logLine("ring health: pull ABORTED - ran all " + commands.length + " types but "
+                + (stillConnected ? "the ring answered none of them" : "the link dropped"));
+            return false;
+        }
+        logLine("ring health: requested " + commands.length + " record types, "
+            + rspCount + " answered");
+        return true;
+    }
+
+    /** Block (worker thread) until the health RSP flag is set or the timeout
+     * elapses. Not correlated to a specific command/seq - like the rest of
+     * this protocol's request path, it trusts the ring answers in order. */
+    private boolean awaitRingHealthRsp(long timeoutMs) {
+        long deadline = SystemClock.elapsedRealtime() + timeoutMs;
+        synchronized (lock) {
+            while (running && ringConnected && !ringHealthRspSeen) {
+                long remaining = deadline - SystemClock.elapsedRealtime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    lock.wait(Math.min(remaining, 100));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return ringHealthRspSeen;
+                }
+            }
+            return ringHealthRspSeen;
+        }
+    }
+
+    /** Block (worker thread) until DATA pages go idle for {@code idleMs},
+     * extending the window on every new page so a real multi-page backlog
+     * transfer isn't cut short. Not filtered by health type - correct given
+     * the ring only has one type in flight at a time (see the class doc
+     * above), so any page arriving here belongs to the type just requested. */
+    private void awaitRingHealthDataIdle(long idleMs) {
+        long idleDeadline = SystemClock.elapsedRealtime() + idleMs;
+        synchronized (lock) {
+            int lastSeenCounter = ringHealthPageCounter;
+            while (running && ringConnected) {
+                long remaining = idleDeadline - SystemClock.elapsedRealtime();
+                if (remaining <= 0) {
+                    return;
+                }
+                if (ringHealthPageCounter != lastSeenCounter) {
+                    lastSeenCounter = ringHealthPageCounter;
+                    idleDeadline = SystemClock.elapsedRealtime() + idleMs;
+                    remaining = idleMs;
+                }
+                try {
+                    lock.wait(Math.min(remaining, 100));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Fire one bare device-channel REQ in the gap between health types,
+     * matching (without waiting on a response) the cadence a real Even sync
+     * uses. See {@link #RING_DEVICE_PING_CMD_LO} for provenance and caveats.
+     */
+    private void sendRingDevicePing(int cmdLo) {
+        byte[] frame;
+        synchronized (lock) {
+            int seq = nextRingSeqLocked();
+            int nonce = nextRingNonceLocked();
+            if (cmdLo == 0x0a) {
+                // The only one of these four that isn't a bare nonce - it
+                // carries the same opaque constant blob as the handshake's
+                // own 0x0a frame (confirmed byte-identical across two
+                // different nights, see sendRingHandshake()'s comments).
+                frame = RingProtocol.buildFrame(RingProtocol.CHAN_DEVICE, RingProtocol.KIND_REQ, 0x00, 0x0a, seq,
+                    concatBytes(le16(nonce), parseHex("f8f53d235ac4ceaa073885cc")));
+            } else {
+                frame = RingProtocol.buildRequest(RingProtocol.CHAN_DEVICE, 0x00, cmdLo, seq, nonce);
+            }
+        }
+        writeRingFrame(frame, "device ping 0x" + Integer.toHexString(cmdLo));
+    }
+
+    /** Write one already-built ring frame. Worker-thread only (blocking). */
+    private boolean writeRingFrame(byte[] frame, String what) {
+        try {
+            boolean ok = bleManager.writeFrames(
+                ringAddress,
+                BleProtocol.R1_WRITE_CHAR_UUID,
+                Collections.singletonList(frame),
+                ConnectionOptions.WRITE_TYPE,
+                ConnectionOptions.WRITE_TIMEOUT_MS
+            );
+            if (!ok) {
+                logLine("ring " + what + " write failed");
+            }
+            return ok;
+        } catch (Throwable t) {
+            logLine("ring " + what + " write error: " + safeMessage(t));
+            return false;
+        }
+    }
+
+    /**
+     * Drain queued ring frames (page ACKs). Worker-thread only. Returns true
+     * when anything was written.
+     */
+    private boolean flushRingOutbound() {
+        boolean wroteAny = false;
+        while (true) {
+            byte[] frame;
+            synchronized (lock) {
+                if (!ringNotificationsReady || ringOutbound.isEmpty()) {
+                    return wroteAny;
+                }
+                frame = ringOutbound.poll();
+            }
+            if (frame == null) {
+                return wroteAny;
+            }
+            wroteAny |= writeRingFrame(frame, "page ack");
+        }
+    }
+
+    private int nextRingSeqLocked() {
+        ringSeq = (ringSeq + 1) & 0xff;
+        if (ringSeq == 0) {
+            ringSeq = 1;
+        }
+        return ringSeq;
+    }
+
+    private int nextRingNonceLocked() {
+        ringNonce = (ringNonce + 1) & 0xffff;
+        return ringNonce;
+    }
+
+    /**
+     * A snapshot of the health buffer together with the watermark identifying
+     * it.
+     *
+     * <p>The two have to come out under ONE lock. Reading the list and the
+     * count separately would let a page land in between, and the consumer would
+     * then clear a record nothing had ingested - the exact failure the
+     * watermark exists to prevent.
+     */
+    public static final class RingHealthBatch {
+        private final List<RingProtocol.HealthRecord> records;
+        private final long watermark;
+
+        RingHealthBatch(List<RingProtocol.HealthRecord> records, long watermark) {
+            this.records = records;
+            this.watermark = watermark;
+        }
+
+        public List<RingProtocol.HealthRecord> getRecords() {
+            return records;
+        }
+
+        /** Total-ever-added at the instant of the snapshot. */
+        public long getWatermark() {
+            return watermark;
+        }
+    }
+
+    /**
+     * Snapshot of everything the ring has pushed and not yet been consumed,
+     * with the watermark needed to hand it back as consumed.
+     */
+    public RingHealthBatch takeRingHealthBatch() {
+        synchronized (lock) {
+            return new RingHealthBatch(new ArrayList<>(ringHealthRecords), ringHealthTotalAdded);
+        }
+    }
+
+    /**
+     * Drop every held record whose identity is below {@code watermark} - that
+     * is, everything the caller has durably stored.
+     *
+     * <p>"Cut and paste instead of copy paste. If you didn't receive the pull
+     * then it should not delete yet." Call this ONLY after the store write has
+     * succeeded; a caller that dies before calling it simply sees the same
+     * records again, which is a no-op at the store.
+     *
+     * <p>Records that arrived after the snapshot sit above the watermark and
+     * are left alone, so a page landing during an ingest is never lost. If the
+     * buffer evicted its oldest in the meantime (see
+     * {@link #RING_HEALTH_MAX_RECORDS}) the arithmetic accounts for it via
+     * {@code ringHealthTotalAdded} rather than clearing the wrong end.
+     *
+     * @return how many records were actually removed.
+     */
+    public int clearRingHealthRecordsBelow(long watermark) {
+        synchronized (lock) {
+            long firstHeldIndex = ringHealthTotalAdded - ringHealthRecords.size();
+            long toRemove = watermark - firstHeldIndex;
+            if (toRemove <= 0) {
+                return 0;
+            }
+            if (toRemove > ringHealthRecords.size()) {
+                toRemove = ringHealthRecords.size();
+            }
+            ringHealthRecords.subList(0, (int) toRemove).clear();
+            return (int) toRemove;
+        }
+    }
+
+    /**
+     * Snapshot of everything the ring has pushed this session, WITHOUT
+     * consuming it.
+     *
+     * <p>Kept for callers that only want to look. The ingest path must use
+     * {@link #takeRingHealthBatch()} instead - a pure copy is what let the
+     * buffer grow unbounded and every tick re-process the whole session.
+     */
+    public List<RingProtocol.HealthRecord> getRingHealthRecords() {
+        synchronized (lock) {
+            return new ArrayList<>(ringHealthRecords);
+        }
     }
 
     private boolean enableRingNotification(String characteristicUuid) {

--- a/App_Resources/Android/src/main/java/com/faceclaw/app/FaceclawBleManager.java
+++ b/App_Resources/Android/src/main/java/com/faceclaw/app/FaceclawBleManager.java
@@ -123,6 +123,26 @@ public class FaceclawBleManager {
     }
 
     public boolean connect(String address, int timeoutMs) {
+        return connect(address, timeoutMs, false);
+    }
+
+    /**
+     * EXPERIMENTAL (2026-09-11): the ring specifically needs autoConnect=true.
+     * Even's own vendor app connects the ring with Android's autoConnect flag
+     * set (confirmed via its own BLE debug log, "connect() - device: ...,
+     * auto: true"), while every other faceclaw connection (both glasses arms)
+     * uses autoConnect=false. Direct connect (false) is faster to establish
+     * but Android supervises it less patiently; a live test tonight showed
+     * the ring-only direct connection dying almost exactly 5 seconds in,
+     * repeatedly, with nothing else competing for it - consistent with a
+     * companion device Android's stack expects to be babied via autoConnect,
+     * not direct-connected like the glasses. autoConnect=true can take much
+     * longer to actually complete (Android manages it as a background
+     * reconnect, not an immediate attempt), so this needs its own longer
+     * timeout - do not reuse CONNECT_TIMEOUT_MS/awaitLatch's short window for
+     * it, that would just trade one spurious failure for another.
+     */
+    public boolean connect(String address, int timeoutMs, boolean autoConnect) {
         if (address == null || address.trim().isEmpty()) {
             throw new IllegalArgumentException("address is required");
         }
@@ -147,7 +167,7 @@ public class FaceclawBleManager {
 
             gatt = device.connectGatt(
                 context,
-                false,
+                autoConnect,
                 gattCallback,
                 BluetoothDevice.TRANSPORT_LE,
                 BluetoothDevice.PHY_LE_2M|BluetoothDevice.PHY_LE_1M

--- a/App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/BleProtocol.java
+++ b/App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/BleProtocol.java
@@ -23,8 +23,27 @@ public class BleProtocol {
     public static final String OTA_DATA_WRITE_UUID = "00002760-08c2-11e1-9073-0e8ac72e0001";
     public static final String OTA_DATA_NOTIFY_UUID = "00002760-08c2-11e1-9073-0e8ac72e0002";
     public static final String RENDER_NOTIFY_UUID = "00002760-08c2-11e1-9073-0e8ac72e6402";
+    // R1 ring, vendor service bae80001-4f05-4503-8e65-3af1f7329d1f. The service
+    // holds two write/notify pairs: bae80010 (write) + bae80011 (notify), and
+    // bae80012 (write) + bae80013 (notify). The health-data protocol
+    // (RingProtocol) rides the SECOND pair.
     public static final String R1_PHONE_NOTIFY_CHAR_UUID = "bae80011-4f05-4503-8e65-3af1f7329d1f";
     public static final String R1_NOTIFY_CHAR_UUID = "bae80013-4f05-4503-8e65-3af1f7329d1f";
+    /**
+     * Where health-data requests and page ACKs are written. Properties are
+     * 0x04 (write without response), so writes use ConnectionOptions.WRITE_TYPE
+     * (WRITE_TYPE_NO_RESPONSE) — which is also what the reference capture shows
+     * (ATT opcode 0x52 Write Command, never 0x12 Write Request).
+     *
+     * Resolved from the phone's own cached GATT database, not guessed: the
+     * bugreport taken alongside the capture contains a [gatt_cache_c73eb8f9c7c5]
+     * block (keyed by the ring's MAC C7:3E:B8:F9:C7:C5) listing
+     *   Characteristic: declaration_handle=0x0014, value_handle=0x0015,
+     *                   uuid=bae80012-4f05-4503-8e65-3af1f7329d1f, prop=0x04
+     * and 0x0015 is exactly the ATT handle every protocol write in the capture
+     * targets. See knowledge/staging/faceclaw-ring-protocol-implement-return.md.
+     */
+    public static final String R1_WRITE_CHAR_UUID = "bae80012-4f05-4503-8e65-3af1f7329d1f";
 
     public static final int PRELUDE_ACK_SID = 0x01;
     public static final int PRELUDE_ACK_MAGIC = 156;

--- a/App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/ConnectionOptions.java
+++ b/App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/ConnectionOptions.java
@@ -10,6 +10,11 @@ public class ConnectionOptions {
     public static final int DESCRIPTOR_TIMEOUT_MS = 5_000;
     public static final int RING_DESIRED_MTU = 247;
     public static final int RING_RECONNECT_DELAY_MS = 2_000;
+    // The ring connects with autoConnect=true (see FaceclawBleManager.connect's
+    // 3-arg overload) - Android manages that as a background reconnect rather
+    // than an immediate attempt, so it needs far more room than the glasses'
+    // direct-connect CONNECT_TIMEOUT_MS. Untuned guess, not measured.
+    public static final int RING_CONNECT_TIMEOUT_MS = 20_000;
     public static final int WRITE_TIMEOUT_MS = 2_000;
     public static final int PRELUDE_TIMEOUT_MS = 2_000;
     // Application security-auth exchange (sid 0x80). The success notification

--- a/App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/RingProtocol.java
+++ b/App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/RingProtocol.java
@@ -1,0 +1,951 @@
+package com.faceclaw.app;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * RingProtocol: frame build/parse plus per-record decoding for the Even R1
+ * ring's health-data channel. Does _not_ include code for actually sending
+ * anything; for that, see FaceclawBleCommunicator (same split as BleProtocol).
+ *
+ * <p>Deliberately free of Android imports so the whole thing can be exercised
+ * with plain javac/java — see notes/ring-protocol-selftest/.
+ *
+ * <p><b>This is a different protocol from BleProtocol's.</b> The glasses speak
+ * an {@code aa21} envelope with a CRC-16/CCITT; the ring speaks a 15-byte
+ * {@code 64 .. 64} header with a CRC-32C. Nothing is shared between them, and
+ * in particular {@link #crc32} must never be pointed at a glasses frame.
+ *
+ * <p>Wire format (offsets from the start of the ATT value):
+ * <pre>
+ *  off size field
+ *   0   1   FLAG      0x00 normally; 0x01 = fragmented, a continuation follows
+ *   1   4   CRC32     little-endian, over bytes [5:] of the *reassembled* frame
+ *   5   1   0x64      constant magic
+ *   6   1   CHAN      0x01 device/system, 0x02 health data
+ *   7   1   0x64      constant magic
+ *   8   1   SEQ       phone-side: one counter shared by both channels
+ *   9   1   0x00      constant
+ *  10   1   KIND      0x00 REQ, 0x01 ACK, 0x02 DATA, 0x03 RSP
+ *  11   1   CMD_HI
+ *  12   1   CMD_LO
+ *  13   2   PLEN      little-endian; equals (total frame length - 5)
+ *  15  ..   PAYLOAD   PLEN - 10 bytes; PAYLOAD[0:2] is a free per-message nonce
+ * </pre>
+ *
+ * <p>Protocol spec and its evidence:
+ * knowledge/staging/faceclaw-ring-protocol-decode-return.md in the TLC
+ * knowledge base. Everything below is implemented from that document; the
+ * places where it is explicitly *not* solved are marked UNSOLVED and are
+ * surfaced raw rather than guessed at.
+ */
+public final class RingProtocol {
+    private RingProtocol() {
+    }
+
+    /** CRC-32C polynomial, MSB-first / non-reflected form. Not CRC-32 (0x04C11DB7). */
+    private static final int CRC32C_POLY = 0x1EDC6F41;
+
+    public static final int MAGIC = 0x64;
+    public static final int HEADER_LEN = 15;
+    /** A continuation frame is FLAG(1) + CRC32(4) and then raw remainder bytes. */
+    public static final int CONTINUATION_PREFIX_LEN = 5;
+
+    public static final int FLAG_PLAIN = 0x00;
+    public static final int FLAG_FRAGMENTED = 0x01;
+
+    public static final int CHAN_DEVICE = 0x01;
+    public static final int CHAN_HEALTH = 0x02;
+
+    public static final int KIND_REQ = 0x00;
+    public static final int KIND_ACK = 0x01;
+    public static final int KIND_DATA = 0x02;
+    public static final int KIND_RSP = 0x03;
+
+    /** Every health record type uses CMD_LO = 0x01; the type lives in CMD_HI. */
+    public static final int CMD_LO_HEALTH = 0x01;
+    public static final int CMD_HI_HEART_RATE = 0x01;
+    public static final int CMD_HI_SPO2 = 0x02;
+    public static final int CMD_HI_HRV = 0x04;
+    public static final int CMD_HI_STEPS = 0x05;
+    public static final int CMD_HI_SLEEP = 0x06;
+
+    /** Device/system channel commands all have CMD_HI = 0x00. */
+    public static final int CMD_HI_DEVICE = 0x00;
+    public static final int CMD_LO_PAGE_ACK = 0x7E;
+
+    /**
+     * The five health pulls, in the order Even's own app issues them:
+     * heart rate, HRV, SpO2, sleep, steps. That order is identical in all four
+     * sync bursts of the reference capture. (It is NOT the order the spec
+     * document happens to list them in — that is just its presentation order.)
+     * Whether the order matters to the ring is untested; matching the app is
+     * the cheapest way not to find out the hard way.
+     */
+    public static final int[] HEALTH_COMMANDS = {
+        CMD_HI_HEART_RATE,
+        CMD_HI_HRV,
+        CMD_HI_SPO2,
+        CMD_HI_SLEEP,
+        CMD_HI_STEPS,
+    };
+
+    /** Constant terminator on every record body of every type. Meaning unknown. */
+    private static final byte[] RECORD_FOOTER = {(byte) 0x94, 0x33, 0x01, 0x00};
+
+    /** ANCHOR field marker: 0x10 0xFF then a u32 LE Unix timestamp. */
+    private static final int ANCHOR_MARK_HI = 0x10;
+    private static final int ANCHOR_MARK_LO = 0xFF;
+
+    /** Returned by anchor/timestamp accessors when the value is not known. */
+    public static final long UNKNOWN_TIME = -1L;
+
+    private static final byte[] EMPTY = new byte[0];
+
+    // ------------------------------------------------------------------
+    // CRC
+    // ------------------------------------------------------------------
+
+    /**
+     * CRC-32C over {@code data[from, to)}: polynomial 0x1EDC6F41, MSB-first,
+     * init 0, no reflection, no final xor. Verified against 188/188 frames in
+     * the reference capture.
+     */
+    public static int crc32(byte[] data, int from, int to) {
+        int crc = 0;
+        for (int i = from; i < to; i++) {
+            crc ^= (data[i] & 0xff) << 24;
+            for (int bit = 0; bit < 8; bit++) {
+                if ((crc & 0x80000000) != 0) {
+                    crc = (crc << 1) ^ CRC32C_POLY;
+                } else {
+                    crc = crc << 1;
+                }
+            }
+        }
+        return crc;
+    }
+
+    public static int crc32(byte[] data) {
+        return crc32(data, 0, data == null ? 0 : data.length);
+    }
+
+    // ------------------------------------------------------------------
+    // Frame building
+    // ------------------------------------------------------------------
+
+    /**
+     * Build one complete, CRC-correct frame. Fragmentation is a receive-side
+     * concern only: nothing we send approaches the 244-byte ATT ceiling.
+     */
+    public static byte[] buildFrame(int chan, int kind, int cmdHi, int cmdLo, int seq, byte[] payload) {
+        byte[] body = payload == null ? EMPTY : payload;
+        int total = HEADER_LEN + body.length;
+        byte[] frame = new byte[total];
+        frame[0] = (byte) FLAG_PLAIN;
+        frame[5] = (byte) MAGIC;
+        frame[6] = (byte) (chan & 0xff);
+        frame[7] = (byte) MAGIC;
+        frame[8] = (byte) (seq & 0xff);
+        frame[9] = 0x00;
+        frame[10] = (byte) (kind & 0xff);
+        frame[11] = (byte) (cmdHi & 0xff);
+        frame[12] = (byte) (cmdLo & 0xff);
+        int plen = total - 5;
+        frame[13] = (byte) (plen & 0xff);
+        frame[14] = (byte) ((plen >>> 8) & 0xff);
+        System.arraycopy(body, 0, frame, HEADER_LEN, body.length);
+        writeIntLe(frame, 1, crc32(frame, 5, total));
+        return frame;
+    }
+
+    /**
+     * A request frame. Health requests carry no arguments at all: the payload
+     * is the 2-byte nonce and nothing else.
+     *
+     * <p>The nonce is a free per-message id — it is covered by the frame CRC but
+     * is not content-derived, so any value works. It is encoded little-endian.
+     */
+    public static byte[] buildRequest(int chan, int cmdHi, int cmdLo, int seq, int nonce) {
+        return buildFrame(chan, KIND_REQ, cmdHi, cmdLo, seq, nonceBytes(nonce));
+    }
+
+    /** One of the five health pulls; see {@link #HEALTH_COMMANDS}. */
+    public static byte[] buildHealthRequest(int cmdHi, int seq, int nonce) {
+        return buildRequest(CHAN_HEALTH, cmdHi, CMD_LO_HEALTH, seq, nonce);
+    }
+
+    /**
+     * The per-page acknowledgement: command 00:7E on the DEVICE channel,
+     * echoing the sequence number of the DATA page being acknowledged.
+     *
+     * <p>Payload is 12 bytes: the usual 2-byte nonce, then
+     * {@code 02 <cmd_hi> <cmd_lo> 00 <page_seq>}, then five zero bytes. (Note
+     * the echoed page seq is at payload offset 6, after the nonce — a spec doc
+     * that describes the payload as starting at {@code 02} is off by the nonce.)
+     *
+     * <p>The frame's own SEQ is the phone's shared counter, NOT the echoed page
+     * seq: across 20 ACKs in the reference capture the two are always different,
+     * and the header SEQ continues the same +1 sequence used by every other
+     * phone-to-ring write on both channels.
+     *
+     * <p>Whether the ring actually *requires* this is untested — Even's app
+     * sends one for every page without exception (20/20), but no page has ever
+     * been deliberately left unacknowledged to see what happens.
+     */
+    public static byte[] buildPageAck(int seq, int nonce, int ackedCmdHi, int ackedCmdLo, int pageSeq) {
+        byte[] payload = new byte[12];
+        payload[0] = (byte) (nonce & 0xff);
+        payload[1] = (byte) ((nonce >>> 8) & 0xff);
+        payload[2] = 0x02;
+        payload[3] = (byte) (ackedCmdHi & 0xff);
+        payload[4] = (byte) (ackedCmdLo & 0xff);
+        payload[5] = 0x00;
+        payload[6] = (byte) (pageSeq & 0xff);
+        // payload[7..11] stay zero.
+        return buildFrame(CHAN_DEVICE, KIND_ACK, CMD_HI_DEVICE, CMD_LO_PAGE_ACK, seq, payload);
+    }
+
+    private static byte[] nonceBytes(int nonce) {
+        return new byte[] {(byte) (nonce & 0xff), (byte) ((nonce >>> 8) & 0xff)};
+    }
+
+    // ------------------------------------------------------------------
+    // Frame parsing and fragment reassembly
+    // ------------------------------------------------------------------
+
+    /** True when a value could be the start of a frame (magic bytes in place). */
+    public static boolean looksLikeHeader(byte[] value) {
+        return value != null
+            && value.length >= HEADER_LEN
+            && (value[5] & 0xff) == MAGIC
+            && (value[7] & 0xff) == MAGIC;
+    }
+
+    /** Total frame length declared by PLEN, or -1 when this is not a header. */
+    public static int declaredLength(byte[] value) {
+        if (!looksLikeHeader(value)) {
+            return -1;
+        }
+        int plen = (value[13] & 0xff) | ((value[14] & 0xff) << 8);
+        int total = plen + 5;
+        return total < HEADER_LEN ? -1 : total;
+    }
+
+    /** Parse a complete (already reassembled) frame. Returns null if malformed. */
+    public static Frame parse(byte[] frame) {
+        if (frame == null || frame.length < HEADER_LEN) {
+            return null;
+        }
+        if ((frame[5] & 0xff) != MAGIC || (frame[7] & 0xff) != MAGIC) {
+            return null;
+        }
+        int plen = (frame[13] & 0xff) | ((frame[14] & 0xff) << 8);
+        if (plen + 5 != frame.length) {
+            return null;
+        }
+        int storedCrc = readIntLe(frame, 1);
+        int actualCrc = crc32(frame, 5, frame.length);
+        byte[] payload = Arrays.copyOfRange(frame, HEADER_LEN, frame.length);
+        return new Frame(
+            frame[0] & 0xff,
+            frame[6] & 0xff,
+            frame[8] & 0xff,
+            frame[10] & 0xff,
+            frame[11] & 0xff,
+            frame[12] & 0xff,
+            payload,
+            frame,
+            storedCrc == actualCrc
+        );
+    }
+
+    /**
+     * Feeds raw ATT notification values in and produces complete frames,
+     * rejoining fragmented ones.
+     *
+     * <p>Fragmentation (spec §2.3): when a frame exceeds the 244-byte ATT
+     * ceiling the ring sets FLAG=0x01, sends the first 244 bytes, and later
+     * sends a continuation frame in a different, headerless shape — FLAG(1),
+     * CRC32(4), then the remaining bytes verbatim.
+     *
+     * <p>Two things the spec document does not say, both measured from the
+     * reference capture and both load-bearing here:
+     * <ul>
+     *   <li><b>The continuation is not adjacent.</b> In one of the six captured
+     *       fragmentations three unrelated complete frames arrive between the
+     *       first fragment and its continuation, so a "next value is the rest"
+     *       rule mis-joins. Complete frames are therefore still parsed normally
+     *       while a fragment is outstanding.</li>
+     *   <li><b>The continuation's own CRC field is not reliably the reassembled
+     *       CRC.</b> It matched in five of six cases and differed in the sixth
+     *       (whose join is nonetheless byte-exact and CRC-valid), so the
+     *       continuation must not be matched by comparing CRC fields.</li>
+     * </ul>
+     *
+     * <p>What is reliable, in all six cases, is length: a continuation carries
+     * exactly {@code CONTINUATION_PREFIX_LEN + bytesStillNeeded} bytes and does
+     * not itself look like a header. The reassembled frame's CRC is the real
+     * validator and is always checked.
+     */
+    public static final class Reassembler {
+        /**
+         * Give up on an outstanding fragment after this many intervening
+         * complete frames. The observed worst case is 3; this is slack, not a
+         * measured bound.
+         */
+        private static final int MAX_INTERLEAVED_FRAMES = 16;
+
+        private byte[] pending;
+        private int pendingTotal;
+        private int interleaved;
+
+        public boolean hasPending() {
+            return pending != null;
+        }
+
+        public void reset() {
+            pending = null;
+            pendingTotal = 0;
+            interleaved = 0;
+        }
+
+        /**
+         * Offer one ATT notification value. The result says whether the value
+         * belonged to this protocol at all (so the caller can fall through to
+         * the gesture decoder) and carries a frame once one is complete.
+         */
+        public Intake accept(byte[] value) {
+            if (value == null || value.length == 0) {
+                return Intake.ignored();
+            }
+
+            if (pending != null) {
+                int needed = pendingTotal - pending.length;
+                if (value.length == CONTINUATION_PREFIX_LEN + needed && !looksLikeHeader(value)) {
+                    byte[] joined = new byte[pendingTotal];
+                    System.arraycopy(pending, 0, joined, 0, pending.length);
+                    System.arraycopy(value, CONTINUATION_PREFIX_LEN, joined, pending.length, needed);
+                    reset();
+                    return complete(joined);
+                }
+                if (!looksLikeHeader(value)) {
+                    int dropped = pendingTotal;
+                    reset();
+                    return Intake.consumed(String.format(
+                        Locale.US,
+                        "dropped %d-byte fragment: continuation was %d bytes, expected %d",
+                        dropped, value.length, CONTINUATION_PREFIX_LEN + needed));
+                }
+                if (++interleaved > MAX_INTERLEAVED_FRAMES) {
+                    int dropped = pendingTotal;
+                    reset();
+                    // Fall through and parse this value as a fresh frame.
+                    Intake result = acceptFresh(value);
+                    return result.withNote(String.format(
+                        Locale.US, "dropped %d-byte fragment: continuation never arrived", dropped));
+                }
+            }
+
+            return acceptFresh(value);
+        }
+
+        private Intake acceptFresh(byte[] value) {
+            int total = declaredLength(value);
+            if (total < 0) {
+                return Intake.ignored();
+            }
+            if (value.length >= total) {
+                return complete(Arrays.copyOf(value, total));
+            }
+            // Only one fragment is ever outstanding in the reference capture,
+            // but never silently clobber one if that assumption breaks.
+            String clobbered = pending == null ? null : String.format(
+                Locale.US, "dropped %d-byte fragment: a new fragment started", pendingTotal);
+            pending = Arrays.copyOf(value, value.length);
+            pendingTotal = total;
+            interleaved = 0;
+            return Intake.consumed(String.format(
+                Locale.US, "fragment start, %d of %d bytes", value.length, total)).withNote(clobbered);
+        }
+
+        private Intake complete(byte[] raw) {
+            Frame frame = parse(raw);
+            if (frame == null) {
+                return Intake.consumed("malformed frame, " + raw.length + " bytes");
+            }
+            return Intake.frame(frame);
+        }
+    }
+
+    /** The outcome of offering one ATT value to a {@link Reassembler}. */
+    public static final class Intake {
+        /** True when the value belonged to this protocol and must not be re-handled. */
+        public final boolean consumed;
+        /** Non-null once a complete frame is available. Check {@link Frame#crcOk}. */
+        public final Frame frame;
+        /** Human-readable detail for logging, or null. */
+        public final String note;
+
+        private Intake(boolean consumed, Frame frame, String note) {
+            this.consumed = consumed;
+            this.frame = frame;
+            this.note = note;
+        }
+
+        static Intake ignored() {
+            return new Intake(false, null, null);
+        }
+
+        static Intake consumed(String note) {
+            return new Intake(true, null, note);
+        }
+
+        static Intake frame(Frame frame) {
+            return new Intake(true, frame, null);
+        }
+
+        Intake withNote(String extra) {
+            if (extra == null) {
+                return this;
+            }
+            return new Intake(consumed, frame, note == null ? extra : note + "; " + extra);
+        }
+    }
+
+    /** One complete frame. */
+    public static final class Frame {
+        public final int flag;
+        public final int chan;
+        public final int seq;
+        public final int kind;
+        public final int cmdHi;
+        public final int cmdLo;
+        /** PLEN - 10 bytes. payload[0:2] is the sender's nonce. */
+        public final byte[] payload;
+        public final byte[] raw;
+        public final boolean crcOk;
+
+        Frame(int flag, int chan, int seq, int kind, int cmdHi, int cmdLo,
+              byte[] payload, byte[] raw, boolean crcOk) {
+            this.flag = flag;
+            this.chan = chan;
+            this.seq = seq;
+            this.kind = kind;
+            this.cmdHi = cmdHi;
+            this.cmdLo = cmdLo;
+            this.payload = payload;
+            this.raw = raw;
+            this.crcOk = crcOk;
+        }
+
+        public boolean isHealth() {
+            return chan == CHAN_HEALTH;
+        }
+
+        public String commandLabel() {
+            return String.format(Locale.US, "%02x:%02x", cmdHi, cmdLo);
+        }
+
+        public String describe() {
+            return String.format(
+                Locale.US,
+                "chan=%02x kind=%02x cmd=%s seq=%02x len=%d",
+                chan, kind, commandLabel(), seq, raw.length);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Record decoding
+    // ------------------------------------------------------------------
+
+    /**
+     * Decode a health DATA page. Returns null when the frame is not a health
+     * DATA page or its body does not match the layout for its type.
+     */
+    public static HealthRecord decode(Frame frame, long receivedAtMs) {
+        if (frame == null || !frame.crcOk || !frame.isHealth() || frame.kind != KIND_DATA) {
+            return null;
+        }
+        if (frame.cmdLo != CMD_LO_HEALTH) {
+            return null;
+        }
+        switch (frame.cmdHi) {
+            case CMD_HI_HEART_RATE:
+            case CMD_HI_SPO2:
+            case CMD_HI_HRV:
+                return decodeHourly(frame, receivedAtMs);
+            case CMD_HI_STEPS:
+                return decodeSteps(frame, receivedAtMs);
+            case CMD_HI_SLEEP:
+                return decodeSleep(frame, receivedAtMs);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Heart rate / SpO2 / HRV: an hourly {@code [index][avg][max][min]} series.
+     *
+     * <p>The value width W is not guessed — it is resolved from the body length
+     * by {@code len == W + COUNT * (1 + 3W)}, which has a unique solution for
+     * every frame in the reference capture (W=1 for HR and SpO2, W=2 for HRV).
+     */
+    public static HourlyRecord decodeHourly(Frame frame, long receivedAtMs) {
+        byte[] pay = frame.payload;
+        if (pay.length < 13 + RECORD_FOOTER.length) {
+            return null;
+        }
+        int count = pay[2] & 0xff;
+        long anchor = anchorUnixSeconds(pay);
+        long tag = readUInt32Le(pay, 9);
+
+        int bodyLen = pay.length - 13 - RECORD_FOOTER.length;
+        int width;
+        if (bodyLen == 1 + count * 4) {
+            width = 1;
+        } else if (bodyLen == 2 + count * 7) {
+            width = 2;
+        } else {
+            return null;
+        }
+
+        int current = readUIntLe(pay, 13, width);
+        int offset = 13 + width;
+        HourlyGroup[] groups = new HourlyGroup[count];
+        for (int i = 0; i < count; i++) {
+            int hourIndex = pay[offset] & 0xff;
+            offset++;
+            int avg = readUIntLe(pay, offset, width);
+            offset += width;
+            int max = readUIntLe(pay, offset, width);
+            offset += width;
+            int min = readUIntLe(pay, offset, width);
+            offset += width;
+            long unix = anchor == UNKNOWN_TIME ? UNKNOWN_TIME : anchor + hourIndex * 3600L;
+            groups[i] = new HourlyGroup(hourIndex, avg, max, min, unix);
+        }
+        return new HourlyRecord(frame.cmdHi, receivedAtMs, anchor, tag, current, width, groups);
+    }
+
+    /**
+     * Steps / activity buckets: {@code [index][v1][v2][v3]} after the record
+     * prefix. v1 (steps) is proven against a full-day total; v2 and v3 are
+     * calorie-shaped but unconfirmed, and the bucket index does NOT map to a
+     * known wall-clock time (see {@link StepsBucket}).
+     */
+    public static StepsRecord decodeSteps(Frame frame, long receivedAtMs) {
+        byte[] pay = frame.payload;
+        if (pay.length < 9 + RECORD_FOOTER.length) {
+            return null;
+        }
+        int count = pay[2] & 0xff;
+        if (pay.length != 9 + count * 7 + RECORD_FOOTER.length) {
+            return null;
+        }
+        long anchor = anchorUnixSeconds(pay);
+        int offset = 9;
+        StepsBucket[] buckets = new StepsBucket[count];
+        for (int i = 0; i < count; i++) {
+            int index = pay[offset] & 0xff;
+            int steps = readUInt16Le(pay, offset + 1);
+            int v2 = readUInt16Le(pay, offset + 3);
+            int v3 = readUInt16Le(pay, offset + 5);
+            offset += 7;
+            buckets[i] = new StepsBucket(index, steps, v2, v3);
+        }
+        return new StepsRecord(receivedAtMs, anchor, buckets);
+    }
+
+    /**
+     * A sleep session. The ring transmits pre-classified stages, per-stage
+     * totals and the session boundaries; nothing is computed phone-side.
+     *
+     * <p>{@code startTs}/{@code endTs} are ring-relative seconds, NOT Unix
+     * timestamps — see {@link SleepRecord}.
+     */
+    public static SleepRecord decodeSleep(Frame frame, long receivedAtMs) {
+        byte[] pay = frame.payload;
+        if (pay.length < 3) {
+            return null;
+        }
+        int recordState = pay[2] & 0xff;
+        byte[] unknownA = safeRange(pay, 3, 9);
+        long unknownTag = pay.length >= 13 ? readUInt32Le(pay, 9) : UNKNOWN_TIME;
+        if (recordState != 1 || pay.length < 34 + RECORD_FOOTER.length) {
+            // RECSTATE 2 is the empty / end-of-list marker.
+            return new SleepRecord(
+                receivedAtMs, recordState, unknownA, unknownTag,
+                0, 0, 0, 0, 0, 0, 0, new SleepSegment[0]);
+        }
+
+        long startTs = readUInt32Le(pay, 14);
+        long endTs = readUInt32Le(pay, 18);
+        int totalTime = readUInt16Le(pay, 22);
+        int wakeTime = readUInt16Le(pay, 24);
+        int remTime = readUInt16Le(pay, 26);
+        int lightTime = readUInt16Le(pay, 28);
+        int deepTime = readUInt16Le(pay, 30);
+        int segmentCount = pay[32] & 0xff;
+        if (pay.length != 34 + segmentCount * 3 + RECORD_FOOTER.length) {
+            return null;
+        }
+        SleepSegment[] segments = new SleepSegment[segmentCount];
+        int offset = 34;
+        for (int i = 0; i < segmentCount; i++) {
+            int stage = pay[offset] & 0xff;
+            int halfMinutes = readUInt16Le(pay, offset + 1);
+            offset += 3;
+            segments[i] = new SleepSegment(stage, halfMinutes);
+        }
+        return new SleepRecord(
+            receivedAtMs, recordState, unknownA, unknownTag,
+            startTs, endTs, totalTime, wakeTime, remTime, lightTime, deepTime, segments);
+    }
+
+    /**
+     * The record's day anchor as Unix epoch seconds, or {@link #UNKNOWN_TIME}
+     * when the anchor field is the six-zero-byte "backlog page" form.
+     *
+     * <p><b>UNSOLVED:</b> a backlog page's true base is not understood as a
+     * general rule. One capture's backlog base landed at 2026-09-08 23:48:49
+     * local, which is the moment that sync ran plus a per-type offset — it is
+     * not a fixed offset from midnight and must not be hardcoded. Callers get
+     * {@link #UNKNOWN_TIME} and the raw hour index instead of an invented
+     * absolute time.
+     */
+    public static long anchorUnixSeconds(byte[] payload) {
+        if (payload == null || payload.length < 9) {
+            return UNKNOWN_TIME;
+        }
+        if ((payload[3] & 0xff) == ANCHOR_MARK_HI && (payload[4] & 0xff) == ANCHOR_MARK_LO) {
+            return readUInt32Le(payload, 5);
+        }
+        return UNKNOWN_TIME;
+    }
+
+    // ------------------------------------------------------------------
+    // Decoded record types
+    // ------------------------------------------------------------------
+
+    /** Common supertype so one store can hold every decoded page. */
+    public abstract static class HealthRecord {
+        public final int cmdHi;
+        public final long receivedAtMs;
+
+        HealthRecord(int cmdHi, long receivedAtMs) {
+            this.cmdHi = cmdHi;
+            this.receivedAtMs = receivedAtMs;
+        }
+
+        /** The metric name, for logs. */
+        public String metric() {
+            switch (cmdHi) {
+                case CMD_HI_HEART_RATE: return "heart_rate";
+                case CMD_HI_SPO2: return "spo2";
+                case CMD_HI_HRV: return "hrv";
+                case CMD_HI_STEPS: return "steps";
+                case CMD_HI_SLEEP: return "sleep";
+                default: return String.format(Locale.US, "cmd%02x", cmdHi);
+            }
+        }
+
+        /** A one-line summary safe to put in a log. */
+        public abstract String summary();
+    }
+
+    /** Heart rate, SpO2 or HRV: one page of hourly buckets. */
+    public static final class HourlyRecord extends HealthRecord {
+        /** Day anchor in Unix seconds, or {@link #UNKNOWN_TIME} on a backlog page. */
+        public final long anchorUnixSeconds;
+        /** Per-metric "last measured at". See the 4-hour skew note in the spec. */
+        public final long tagRaw;
+        /** The metric's latest value. */
+        public final int current;
+        /** 1 byte for HR/SpO2, 2 for HRV; resolved from the body length. */
+        public final int valueWidth;
+        public final HourlyGroup[] groups;
+
+        HourlyRecord(int cmdHi, long receivedAtMs, long anchorUnixSeconds, long tagRaw,
+                     int current, int valueWidth, HourlyGroup[] groups) {
+            super(cmdHi, receivedAtMs);
+            this.anchorUnixSeconds = anchorUnixSeconds;
+            this.tagRaw = tagRaw;
+            this.current = current;
+            this.valueWidth = valueWidth;
+            this.groups = groups;
+        }
+
+        /** True when this page has no anchor, i.e. it is a backlog page. */
+        public boolean isBacklog() {
+            return anchorUnixSeconds == UNKNOWN_TIME;
+        }
+
+        @Override public String summary() {
+            return String.format(
+                Locale.US,
+                "%s groups=%d width=%d current=%d anchor=%s tag=%d",
+                metric(), groups.length, valueWidth, current,
+                isBacklog() ? "backlog(unanchored)" : Long.toString(anchorUnixSeconds),
+                tagRaw);
+        }
+    }
+
+    /** One hourly bucket. */
+    public static final class HourlyGroup {
+        /** Raw index as sent. On an anchored page this is hours since the anchor. */
+        public final int hourIndex;
+        public final int avg;
+        public final int max;
+        public final int min;
+        /**
+         * Absolute Unix seconds for this bucket, or {@link #UNKNOWN_TIME} on a
+         * backlog page — where the base is UNSOLVED and deliberately not guessed.
+         */
+        public final long unixSeconds;
+
+        HourlyGroup(int hourIndex, int avg, int max, int min, long unixSeconds) {
+            this.hourIndex = hourIndex;
+            this.avg = avg;
+            this.max = max;
+            this.min = min;
+            this.unixSeconds = unixSeconds;
+        }
+    }
+
+    /** One page of activity buckets. */
+    public static final class StepsRecord extends HealthRecord {
+        public final long anchorUnixSeconds;
+        public final StepsBucket[] buckets;
+
+        StepsRecord(long receivedAtMs, long anchorUnixSeconds, StepsBucket[] buckets) {
+            super(CMD_HI_STEPS, receivedAtMs);
+            this.anchorUnixSeconds = anchorUnixSeconds;
+            this.buckets = buckets;
+        }
+
+        public int totalSteps() {
+            int total = 0;
+            for (StepsBucket bucket : buckets) {
+                total += bucket.steps;
+            }
+            return total;
+        }
+
+        @Override public String summary() {
+            return String.format(
+                Locale.US,
+                "steps buckets=%d total=%d anchor=%s",
+                buckets.length, totalSteps(),
+                anchorUnixSeconds == UNKNOWN_TIME ? "none" : Long.toString(anchorUnixSeconds));
+        }
+    }
+
+    /**
+     * One activity bucket.
+     *
+     * <p><b>UNSOLVED:</b> {@link #index} does not map to a known wall-clock
+     * time. It runs 0-7, 10, 11, 13-34 and then jumps to 130+, and no bucket
+     * width at any base reproduces the app's own per-bucket distribution — even
+     * though the steps total across all buckets is exactly right. The raw index
+     * is stored as sent; no time-of-day mapping is invented.
+     */
+    public static final class StepsBucket {
+        public final int index;
+        /** Confirmed: summed over a page this equals the app's daily step total. */
+        public final int steps;
+        /** UNCONFIRMED: calorie-shaped (v3 - v2 tracks per-bucket resting kcal). */
+        public final int calorieLike2;
+        /** UNCONFIRMED: calorie-shaped. */
+        public final int calorieLike3;
+
+        StepsBucket(int index, int steps, int calorieLike2, int calorieLike3) {
+            this.index = index;
+            this.steps = steps;
+            this.calorieLike2 = calorieLike2;
+            this.calorieLike3 = calorieLike3;
+        }
+    }
+
+    /**
+     * One sleep session.
+     *
+     * <p><b>{@link #startTs} and {@link #endTs} are ring-relative seconds, not
+     * Unix time.</b> Even's own app gets this wrong and stamps live-pushed
+     * sessions with timestamps in 1979. Do not feed them to a date formatter.
+     *
+     * <p><b>UNSOLVED:</b> {@link #unknownPrefix} (6 bytes) and
+     * {@link #unknownTag} (u32) are not decoded; one of them probably carries
+     * the session date, which would remove the anchoring problem. They are
+     * stored raw rather than interpreted.
+     */
+    public static final class SleepRecord extends HealthRecord {
+        /** 1 = a real record, 2 = the empty / end-of-list marker. */
+        public final int recordState;
+        /** UNSOLVED per-record 6-byte field (payload[3:9]). Stored raw. */
+        public final byte[] unknownPrefix;
+        /** UNSOLVED u32 tag (payload[9:13]). Stored raw. */
+        public final long unknownTag;
+        /** Ring-relative seconds, NOT Unix. */
+        public final long startTs;
+        /** Ring-relative seconds, NOT Unix. */
+        public final long endTs;
+        public final int totalTime;
+        public final int wakeTime;
+        public final int remTime;
+        public final int lightTime;
+        public final int deepTime;
+        /**
+         * The stage series. Stage ids are the same 0-3 encoding the app's own
+         * export uses, but which id means wake/rem/light/deep is NOT stated by
+         * the spec and is deliberately not guessed here — see
+         * {@link #halfMinutesForStage}.
+         */
+        public final SleepSegment[] segments;
+
+        SleepRecord(long receivedAtMs, int recordState, byte[] unknownPrefix, long unknownTag,
+                    long startTs, long endTs, int totalTime, int wakeTime, int remTime,
+                    int lightTime, int deepTime, SleepSegment[] segments) {
+            super(CMD_HI_SLEEP, receivedAtMs);
+            this.recordState = recordState;
+            this.unknownPrefix = unknownPrefix;
+            this.unknownTag = unknownTag;
+            this.startTs = startTs;
+            this.endTs = endTs;
+            this.totalTime = totalTime;
+            this.wakeTime = wakeTime;
+            this.remTime = remTime;
+            this.lightTime = lightTime;
+            this.deepTime = deepTime;
+            this.segments = segments;
+        }
+
+        public boolean isRealRecord() {
+            return recordState == 1;
+        }
+
+        public int totalHalfMinutes() {
+            int total = 0;
+            for (SleepSegment segment : segments) {
+                total += segment.halfMinutes;
+            }
+            return total;
+        }
+
+        public int halfMinutesForStage(int stage) {
+            int total = 0;
+            for (SleepSegment segment : segments) {
+                if (segment.stage == stage) {
+                    total += segment.halfMinutes;
+                }
+            }
+            return total;
+        }
+
+        /**
+         * The two whole-record arithmetic identities from the spec, which held
+         * exactly for all ten real records in the reference capture. A false
+         * result means the body was mis-parsed.
+         */
+        public boolean identitiesHold() {
+            if (!isRealRecord()) {
+                return true;
+            }
+            int seconds = totalHalfMinutes() * 30;
+            return seconds == totalTime + wakeTime && seconds == (int) (endTs - startTs);
+        }
+
+        @Override public String summary() {
+            if (!isRealRecord()) {
+                return String.format(Locale.US, "sleep marker state=%d", recordState);
+            }
+            return String.format(
+                Locale.US,
+                "sleep segments=%d total=%ds wake=%d rem=%d light=%d deep=%d relStart=%d relEnd=%d identities=%s",
+                segments.length, totalTime, wakeTime, remTime, lightTime, deepTime,
+                startTs, endTs, identitiesHold());
+        }
+    }
+
+    /** One stage run: a stage id and a duration in half-minutes (30 s units). */
+    public static final class SleepSegment {
+        public final int stage;
+        public final int halfMinutes;
+
+        SleepSegment(int stage, int halfMinutes) {
+            this.stage = stage;
+            this.halfMinutes = halfMinutes;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Little-endian helpers
+    // ------------------------------------------------------------------
+
+    private static void writeIntLe(byte[] out, int offset, int value) {
+        out[offset] = (byte) (value & 0xff);
+        out[offset + 1] = (byte) ((value >>> 8) & 0xff);
+        out[offset + 2] = (byte) ((value >>> 16) & 0xff);
+        out[offset + 3] = (byte) ((value >>> 24) & 0xff);
+    }
+
+    private static int readIntLe(byte[] data, int offset) {
+        return (data[offset] & 0xff)
+            | ((data[offset + 1] & 0xff) << 8)
+            | ((data[offset + 2] & 0xff) << 16)
+            | ((data[offset + 3] & 0xff) << 24);
+    }
+
+    private static long readUInt32Le(byte[] data, int offset) {
+        return readIntLe(data, offset) & 0xffffffffL;
+    }
+
+    private static int readUInt16Le(byte[] data, int offset) {
+        return (data[offset] & 0xff) | ((data[offset + 1] & 0xff) << 8);
+    }
+
+    private static int readUIntLe(byte[] data, int offset, int width) {
+        int value = 0;
+        for (int i = 0; i < width; i++) {
+            value |= (data[offset + i] & 0xff) << (8 * i);
+        }
+        return value;
+    }
+
+    private static byte[] safeRange(byte[] data, int from, int to) {
+        if (data == null || from >= data.length) {
+            return EMPTY;
+        }
+        return Arrays.copyOfRange(data, from, Math.min(to, data.length));
+    }
+
+    /** Hex, for logs. Mirrors FaceclawBleCommunicator.hex(). */
+    public static String hex(byte[] data) {
+        if (data == null || data.length == 0) {
+            return "";
+        }
+        char[] digits = "0123456789abcdef".toCharArray();
+        char[] out = new char[data.length * 2];
+        for (int i = 0; i < data.length; i++) {
+            int value = data[i] & 0xff;
+            out[i * 2] = digits[value >>> 4];
+            out[i * 2 + 1] = digits[value & 0x0f];
+        }
+        return new String(out);
+    }
+
+    /** The five health requests, ready to write, sharing one ascending seq run. */
+    public static List<byte[]> buildHealthRequestBurst(int firstSeq, int firstNonce) {
+        List<byte[]> frames = new ArrayList<>(HEALTH_COMMANDS.length);
+        int seq = firstSeq;
+        int nonce = firstNonce;
+        for (int cmdHi : HEALTH_COMMANDS) {
+            frames.add(buildHealthRequest(cmdHi, seq, nonce));
+            seq = (seq + 1) & 0xff;
+            nonce = (nonce + 1) & 0xffff;
+        }
+        return frames;
+    }
+}

--- a/app/app.css
+++ b/app/app.css
@@ -698,3 +698,681 @@ Button.permissions-primary-dimmed {
 .ns-dark .transcript-play {
   color: #7da7f5;
 }
+
+
+
+/*
+ * The cover screen (phone-ui/cover-glance.xml): what the phone shows while the
+ * Fold is shut. It reuses .home-card and .home-section-title wholesale — the
+ * cover screen is the same product, laid out for a glance, not a second visual
+ * language — and adds only what a one-screenful layout needs.
+ */
+.cover-glance {
+  padding: 12 12 16 12;
+}
+
+.cover-glance-card {
+  vertical-align: center;
+  margin-top: 0;
+}
+
+.cover-glance-app {
+  font-size: 20;
+  font-weight: bold;
+  color: #222222;
+}
+
+.cover-glance-text {
+  font-size: 15;
+  color: #444444;
+  margin-top: 6;
+}
+
+.cover-glance-hint {
+  font-size: 12;
+  color: #888888;
+  text-align: center;
+  margin-top: 12;
+}
+
+.ns-dark .cover-glance-app {
+  color: #f0f0f0;
+}
+
+.ns-dark .cover-glance-text {
+  color: #cfcfcf;
+}
+
+.ns-dark .cover-glance-hint {
+  color: #909090;
+}
+
+/*
+ * Ghost's companion (phone-ui/ghost-companion.xml). The pilot's own palette is
+ * deliberately NOT ported: it was a black OLED mockup with phosphor-green
+ * accents standing in for a whole OS shell, and this screen lives inside the
+ * Faceclaw app, whose light/dark surfaces every other page already uses. What
+ * carries over is the structure — header, tab bar, one pane, docked compose —
+ * and the monospace treatment of the raw views, which is load-bearing.
+ */
+.ghost-app {
+  background-color: #ffffff;
+}
+
+/* The one header row every companion view shares — phone-ui/exocortex-header
+ * .xml. One line, and it replaces BOTH the app-switch bar and the per-app
+ * wordmark/status header that used to stack above the content. */
+.exocortex-header {
+  padding: 5 14;
+  background-color: #f4f4f4;
+  border-bottom-width: 1;
+  border-bottom-color: #dddddd;
+}
+
+/* The tap target back to the hub, so it is coloured like the link it is. */
+.exocortex-header-home {
+  font-family: monospace;
+  font-size: 12;
+  letter-spacing: 0.12;
+  color: #3b6fd6;
+}
+
+.exocortex-header-sep {
+  font-size: 12;
+  color: #aaaaaa;
+  margin-left: 6;
+  margin-right: 6;
+}
+
+/* The star column: the app name takes the slack and truncates before it
+ * pushes the connection status off the row. */
+.exocortex-header-app {
+  font-size: 13;
+  font-weight: bold;
+  color: #222222;
+}
+
+.exocortex-header-status {
+  font-size: 12;
+  color: #666666;
+}
+
+/* The two segments that came down from the ActionBar when main-page lost it
+ * (round 3). Both are collapsed-width by default in the grid, so they cost
+ * nothing horizontally until they are drawn — and nothing vertically ever,
+ * since the row was already there. The padding is the tap target: these are
+ * Labels, so without it the hit box is the glyph. */
+
+/* The emoji brings its own yellow. Collapsed unless a warning is live. */
+.exocortex-header-warning {
+  font-size: 14;
+  padding: 2 4;
+  margin-left: 6;
+}
+
+/* Coloured like the link it is, matching the "Exocortex" tap target at the
+ * other end of the row. */
+.exocortex-header-settings {
+  font-size: 15;
+  color: #3b6fd6;
+  padding: 2 4;
+  margin-left: 8;
+}
+
+.ghost-tab-bar {
+  padding: 2 8 3 8;
+}
+
+/* SHORTER, still four real buttons (Chris, round 2: "shrink the four pane-nav
+ * buttons - still functional, just shorter"). An Android Button carries a
+ * 48dp minimum height from the platform theme, so the explicit height is what
+ * actually shrinks it; padding alone would not. */
+.ghost-tab {
+  font-size: 12;
+  height: 30;
+  padding: 3 0;
+  margin: 0 2;
+  border-radius: 6;
+  background-color: #e2e2e2;
+  color: #333333;
+}
+
+.ghost-tab-active {
+  background-color: #424242;
+  color: #ffffff;
+}
+
+/* The explicit background is LOAD-BEARING, not decoration. Rich view used to
+ * survive the live-theme-switch bug (the app reads the system theme once at
+ * launch and never re-subscribes, so a mid-session switch leaves foreground
+ * and background disagreeing — Terminal and Doc go white-on-white) purely
+ * because every turn was a card carrying its own background colour. Removing
+ * those cards to fix the turn-grouping bug would have removed that immunity
+ * with them. Painting the pane body instead keeps background and text driven
+ * by the SAME .ns-dark state, at the container rather than per row. */
+.ghost-pane-body {
+  padding: 8 16 16 16;
+  background-color: #ffffff;
+}
+
+.ghost-empty {
+  font-size: 14;
+  color: #666666;
+  padding: 24 0;
+  text-align: center;
+}
+
+/* Rich view renders one logical TURN as a continuous block: consecutive prose
+ * runs together at one weight, and tool activity collapses to small muted
+ * marker lines BETWEEN the prose. Deliberately NOT a card per row — round 4
+ * gave every transcript entry the same bordered box with a bold 16pt
+ * headline, so a one-line `Read foo.ts` marker outweighed the reply it sat
+ * inside. Same convention cc-web's own rich view already proves
+ * (apps/claude-code-web/src/public/style.css, `.rich-tool-lines`): "muted so
+ * prose stays primary." */
+.ghost-seg {
+  padding-left: 2;
+  padding-right: 2;
+}
+
+/* The separator lives at the END of a logical turn, not between its own
+ * segments — that is what makes one reply read as one block. */
+.ghost-seg-end {
+  padding-bottom: 14;
+  margin-bottom: 14;
+  border-bottom-width: 1;
+  border-bottom-color: #e2e2e2;
+}
+
+/* The segment the LENS has under its cursor. The phone and the glasses are
+ * two views of one session, so the phone says where the wearer is rather than
+ * keeping a cursor of its own. A left rule rather than a box, so marking it
+ * cannot reintroduce the per-segment card this pass removed. */
+.ghost-seg-current {
+  border-left-width: 3;
+  border-left-color: #3b6fd6;
+  padding-left: 9;
+}
+
+.ghost-seg-who {
+  font-size: 11;
+  text-transform: uppercase;
+  letter-spacing: 0.08;
+  color: #666666;
+  margin-bottom: 3;
+}
+
+/* Prose is the content. One weight, no headline split — splitHeadlineBody()
+ * is the glasses digest's convention and does not belong on a full reply. */
+.ghost-seg-prose {
+  font-size: 16;
+  color: #222222;
+  margin-top: 2;
+  margin-bottom: 2;
+}
+
+/* Tool markers: small, monospace, muted, and almost no vertical space. */
+.ghost-seg-tool {
+  font-family: monospace;
+  font-size: 11;
+  color: #8a8a8a;
+  margin-top: 3;
+  margin-bottom: 3;
+}
+
+/* Surfaced AskUserQuestion turns — a side channel, tinted so they do not read
+ * as something Ghost said mid-sentence. Must stay AFTER .ghost-seg-prose:
+ * both classes are applied to the same Label. */
+.ghost-seg-question {
+  border-left-width: 3;
+  border-left-color: #a371f7;
+  padding-left: 10;
+}
+
+.ghost-seg-answer {
+  border-left-width: 3;
+  border-left-color: #3fb950;
+  padding-left: 10;
+}
+
+/* Not a live terminal — the undigested feed. Monospace because the alignment
+ * is the point: this pane exists for the moment Rich view looks wrong. */
+.ghost-terminal {
+  font-family: monospace;
+  font-size: 12;
+  color: #222222;
+  padding: 12 16;
+}
+
+.ghost-doc-bar {
+  padding: 10 16;
+  background-color: #f4f4f4;
+  border-bottom-width: 1;
+  border-bottom-color: #dddddd;
+}
+
+.ghost-doc-path {
+  font-size: 13;
+  color: #666666;
+}
+
+.ghost-doc-close {
+  font-size: 16;
+  color: #666666;
+  padding: 0 8;
+  background-color: transparent;
+}
+
+/* The container the rendered markdown blocks sit in. `color` and `font-size`
+ * are inheritable in NativeScript, so every .doc-md Label below picks its body
+ * text up from here and only overrides what it actually changes. The explicit
+ * background is the same load-bearing one .ghost-pane-body carries: without it
+ * this pane goes white-on-white after a live theme switch. */
+.ghost-doc-body {
+  font-size: 15;
+  color: #222222;
+  background-color: #ffffff;
+  padding: 14 16 24 16;
+}
+
+/* ── Doc viewer: rendered markdown (2026-09-03) ─────────────────────────────
+ * One Label per parsed block (phone-ui/markdown-render.ts). Block-level
+ * treatment lives here; the inline runs (bold / italic / code / link) are
+ * spans built in ghost-companion-view-model.ts, because a Span's weight and
+ * family cannot be reached from CSS. */
+.doc-md {
+  margin-bottom: 8;
+}
+
+.doc-md-h1 {
+  font-size: 21;
+  margin-top: 14;
+  margin-bottom: 6;
+}
+
+.doc-md-h2 {
+  font-size: 18;
+  margin-top: 14;
+  margin-bottom: 6;
+}
+
+.doc-md-h3 {
+  font-size: 16;
+  margin-top: 12;
+  margin-bottom: 4;
+}
+
+.doc-md-h4 {
+  font-size: 15;
+  margin-top: 12;
+  margin-bottom: 4;
+}
+
+.doc-md-li {
+  margin-bottom: 4;
+}
+
+/* Nesting depth, clamped at three by the parser so a deep list cannot indent
+ * itself off the side of a phone. */
+.doc-md-li-d0 {
+  margin-left: 4;
+}
+
+.doc-md-li-d1 {
+  margin-left: 20;
+}
+
+.doc-md-li-d2 {
+  margin-left: 36;
+}
+
+.doc-md-li-d3 {
+  margin-left: 52;
+}
+
+.doc-md-code {
+  font-family: monospace;
+  font-size: 13;
+  color: #333333;
+  background-color: #f2f2f2;
+  border-radius: 6;
+  padding: 8 10;
+}
+
+.doc-md-quote {
+  border-left-width: 3;
+  border-left-color: #c8c8c8;
+  padding-left: 10;
+  color: #555555;
+}
+
+/* An empty Label doing the job of an <hr>: the block carries no text, so its
+ * height and colour are the whole rule. */
+.doc-md-rule {
+  height: 1;
+  margin: 12 0;
+  background-color: #dddddd;
+}
+
+.ghost-setting {
+  padding: 10 12;
+  margin-bottom: 8;
+  border-radius: 10;
+  border-width: 1;
+  border-color: #dddddd;
+  background-color: #f4f4f4;
+}
+
+.ghost-setting-label {
+  font-size: 15;
+  font-weight: bold;
+  color: #222222;
+}
+
+.ghost-setting-desc {
+  font-size: 12;
+  color: #666666;
+  margin-top: 2;
+}
+
+.ghost-setting-field {
+  font-size: 14;
+  color: #222222;
+  background-color: #ffffff;
+  margin-top: 6;
+}
+
+/* The one thing this screen does that the lens cannot, so it is docked rather
+ * than reached for. */
+.ghost-compose {
+  padding: 8 12 12 12;
+  border-top-width: 1;
+  border-top-color: #dddddd;
+  background-color: #f4f4f4;
+}
+
+/* 48, not the 88 it was. CHECKED, not assumed: NativeScript core has a
+ * minHeightProperty but NO max-height, so letting this auto-size would grow
+ * the docked bar without a ceiling as you type and push the panes off screen.
+ * A fixed height scrolls internally instead, which is the right behaviour for
+ * a bar docked under the content it is about. */
+.ghost-compose-input {
+  height: 48;
+  font-size: 15;
+  color: #222222;
+  background-color: #ffffff;
+  border-radius: 8;
+  padding: 8;
+}
+
+.ghost-send {
+  margin-left: 8;
+}
+
+.ghost-compose-status {
+  font-size: 12;
+  color: #a04040;
+  margin-top: 4;
+}
+
+.ns-dark .ghost-app {
+  background-color: #1c1c1c;
+}
+
+.ns-dark .exocortex-header,
+.ns-dark .ghost-doc-bar,
+.ns-dark .ghost-compose {
+  border-bottom-color: #4a4a4a;
+  border-top-color: #4a4a4a;
+}
+
+.ns-dark .exocortex-header,
+.ns-dark .ghost-doc-bar,
+.ns-dark .ghost-compose {
+  background-color: #2e2e2e;
+}
+
+.ns-dark .exocortex-header-app,
+.ns-dark .ghost-seg-prose,
+.ns-dark .ghost-terminal,
+.ns-dark .ghost-doc-body,
+.ns-dark .ghost-setting-label {
+  color: #f0f0f0;
+}
+
+.ns-dark .exocortex-header-status,
+.ns-dark .ghost-empty,
+.ns-dark .ghost-seg-who,
+.ns-dark .ghost-doc-path,
+.ns-dark .ghost-setting-desc {
+  color: #a0a0a0;
+}
+
+.ns-dark .exocortex-header-sep {
+  color: #6a6a6a;
+}
+
+.ns-dark .ghost-seg-tool {
+  color: #909090;
+}
+
+/* See .ghost-pane-body's own comment: this pairing is what keeps Rich view
+ * readable now that it no longer boxes every segment. */
+.ns-dark .ghost-pane-body {
+  background-color: #1e1e1e;
+}
+
+.ns-dark .ghost-seg-end {
+  border-bottom-color: #3d3d3d;
+}
+
+.ns-dark .exocortex-header-home,
+.ns-dark .exocortex-header-settings {
+  color: #8ab0ff;
+}
+
+.ns-dark .ghost-setting {
+  background-color: #2e2e2e;
+  border-color: #4a4a4a;
+}
+
+.ns-dark .ghost-seg-current {
+  border-left-color: #8ab0ff;
+}
+
+.ns-dark .ghost-setting-field,
+.ns-dark .ghost-compose-input {
+  color: #f0f0f0;
+  background-color: #1c1c1c;
+}
+
+.ns-dark .ghost-tab {
+  background-color: #3a3a3a;
+  color: #e0e0e0;
+}
+
+.ns-dark .ghost-tab-active {
+  background-color: #8ab0ff;
+  color: #101010;
+}
+
+.ns-dark .ghost-compose-status {
+  color: #ff9a8a;
+}
+
+/* Exocortex's own phone settings screens (Settings, Notification sources,
+ * Apps on the glasses). Card rows rather than the flat `.settings-row` used
+ * by the mirror page's controls: these are a list you read down, and a
+ * comfortable thumb target matters more here than density. */
+.exo-row {
+  background-color: #f4f4f4;
+  border-color: #dddddd;
+  border-width: 1;
+  border-radius: 10;
+  padding: 12 14;
+  margin-bottom: 8;
+}
+
+.settings-value {
+  font-size: 14;
+  color: #3b6fd6;
+  margin-left: 12;
+}
+
+.app-order-button {
+  font-size: 18;
+  width: 40;
+  padding: 0;
+  margin: 0 0 0 4;
+  background-color: transparent;
+  color: #3b6fd6;
+}
+
+.ns-dark .exo-row {
+  background-color: #2e2e2e;
+  border-color: #4a4a4a;
+}
+
+.ns-dark .settings-value,
+.ns-dark .app-order-button {
+  color: #8ab0ff;
+}
+
+/* Doc viewer's rendered markdown, dark. Only what actually differs: the body
+ * text colour already comes from .ns-dark .ghost-doc-body above. */
+.ns-dark .ghost-doc-body {
+  background-color: #1c1c1c;
+}
+
+.ns-dark .doc-md-code {
+  color: #d8d8d8;
+  background-color: #262626;
+}
+
+.ns-dark .doc-md-quote {
+  border-left-color: #4a4a4a;
+  color: #b0b0b0;
+}
+
+.ns-dark .doc-md-rule {
+  background-color: #3a3a3a;
+}
+
+/* The app list's own container paints its own background (2026-09-03). The
+ * real cause of "the ghost app rendered on the app grid's background" was the
+ * broken visibility binding fixed in main-page.xml, not a transparent view —
+ * but the two bodies share one grid cell, so whichever is up must own its
+ * backdrop rather than depending on the other being gone. Belt as well as
+ * braces: the same class of bug (a view not painting its own background) is
+ * what the live-theme-switch failure was made of too. */
+.exocortex-home-body {
+  background-color: #ffffff;
+}
+
+.ns-dark .exocortex-home-body {
+  background-color: #1c1c1c;
+}
+
+/* ------------------------------------------------------------------------
+ * HEALTH (phone-ui/health-page.xml)
+ *
+ * The chart is a grayscale bitmap produced by the same GrayImage renderer the
+ * glasses use, so it arrives as light-on-black whatever the phone theme is.
+ * Rather than fight that, the chart gets an explicit dark plate in BOTH
+ * themes - it reads as an instrument panel inset into the page, which is the
+ * one place a fixed dark surface is defensible in a light-themed app. The
+ * chrome around it (chips, stat rows) follows the theme normally.
+ */
+
+.health-chart {
+  background-color: #101010;
+  border-radius: 10;
+  margin: 10 0 6 0;
+}
+
+.health-chip {
+  font-size: 13;
+  color: #444444;
+  background-color: #f0f0f0;
+  border-color: #dddddd;
+  border-width: 1;
+  border-radius: 14;
+  padding: 6 12;
+  margin: 2 6 2 0;
+}
+
+.health-chip-on {
+  color: #ffffff;
+  background-color: #222222;
+  border-color: #222222;
+}
+
+.health-chip-scroll {
+  margin-top: 4;
+}
+
+.health-stat-row {
+  padding: 7 2;
+}
+
+.health-stat-label {
+  font-size: 13;
+  color: #666666;
+}
+
+.health-stat-value {
+  font-size: 15;
+  font-weight: bold;
+  color: #222222;
+}
+
+.health-stat-panel {
+  margin-left: 16;
+}
+
+.health-badge {
+  font-size: 11;
+  color: #8a6d00;
+  background-color: #fff3cd;
+  border-color: #ffe08a;
+  border-width: 1;
+  border-radius: 8;
+  padding: 3 8;
+}
+
+/* Not debug leftover - see health-page.xml's header. */
+.health-layout-meta {
+  font-size: 11;
+  color: #999999;
+  margin-top: 14;
+}
+
+.ns-dark .health-chip {
+  color: #cccccc;
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+
+.ns-dark .health-chip-on {
+  color: #111111;
+  background-color: #e8e8e8;
+  border-color: #e8e8e8;
+}
+
+.ns-dark .health-stat-label {
+  color: #999999;
+}
+
+.ns-dark .health-stat-value {
+  color: #f0f0f0;
+}
+
+.ns-dark .health-badge {
+  color: #ffd97a;
+  background-color: #3a3320;
+  border-color: #5a4c1f;
+}
+
+.ns-dark .health-layout-meta {
+  color: #777777;
+}

--- a/app/app.ts
+++ b/app/app.ts
@@ -13,6 +13,34 @@ installNativeUserAgent()
 registerShareIntentHandler()
 registerPhoneRotation()
 
+import { resyncSystemAppearance } from './native/system-appearance'
+import { startLiveHealthSync, startAlignedRingPull } from './health/health-live'
+
+installNativeUserAgent()
+registerShareIntentHandler()
+
+// Ring health records live only in the communicator's memory until something
+// stores them. Both health surfaces store on open, but a pull that lands while
+// they are closed would be lost if the process restarted first, so this keeps
+// them reaching disk regardless. No-op when there is nothing new.
+startLiveHealthSync()
+
+// Collect from the ring on a wall-clock cadence (:01 and :31). Without this
+// nothing drives a pull on a timer at all - only onRingReady() on reconnect -
+// so a ring that stays connected is never read.
+startAlignedRingPull()
+
+// Live system dark/light switches while the app is running were confirmed
+// (Chris, both directions, 2026-09-02) to leave the Ghost companion's Terminal
+// and Doc panes white-on-white and Rich View visually dark-locked -- while a
+// COLD launch in either theme renders correctly. That proves the app.css
+// .ns-dark rules themselves are right and the LIVE-UPDATE signal is the gap,
+// not any one pane's styling -- see system-appearance.ts for the actual fix
+// and why it resyncs from two triggers instead of trusting the framework's
+// own automatic recolor alone.
+Application.on(Application.systemAppearanceChangedEvent, resyncSystemAppearance)
+Application.on(Application.resumeEvent, resyncSystemAppearance)
+
 Application.run({ moduleName: 'app-root' })
 
 // Don't place any code after the application has been started

--- a/app/apps/all-apps.ts
+++ b/app/apps/all-apps.ts
@@ -7,6 +7,7 @@ import terminalApp from "./terminal";
 import filesApp from "./files";
 import musicApp from "./music";
 import nightscoutApp from "./nightscout";
+import healthApp from "./health";
 import transcribeApp from "./transcribe";
 import teleprompterApp from "./teleprompter";
 import microphonesApp from "./microphones";
@@ -40,6 +41,7 @@ export const ALL_APPS: readonly AppDefinition[] = [
   filesApp,
   musicApp,
   nightscoutApp,
+  healthApp,
   transcribeApp,
   teleprompterApp,
   microphonesApp,

--- a/app/apps/health/health-app.ts
+++ b/app/apps/health/health-app.ts
@@ -1,0 +1,198 @@
+/**
+ * HEALTH - the glasses status page.
+ *
+ * This file is now PLUMBING ONLY: the store reads, the refresh timer, the
+ * scroll cursor, the window lifecycle. Every pixel is drawn by
+ * `health/health-glance.ts`, which has no NativeScript imports and therefore
+ * renders under plain node - see `tools/health-preview.cjs`, which produces a
+ * PNG of each page below without an emulator. The first pass drew and plumbed
+ * in one file and could only be looked at by booting an AVD; that is the
+ * difference this split buys, and it is the reason to keep the two apart.
+ *
+ * ## The surface, after Chris's 2026-09-10 review
+ *
+ * The overview is a SUMMARY - text only, no charts - and scrolling walks a
+ * cursor through a detail page per parameter, ending at sleep's own view.
+ * `GLANCE_PAGES` in `health-glance.ts` is the page list, and the doc comment
+ * there carries the reasoning for the carousel (including which parts of it are
+ * interpretation rather than spec).
+ */
+
+import { getDefaultLargeFont, getDefaultSmallFont } from "../../graphics/ui-fonts";
+import { GrayImage } from "../../graphics/image";
+import { type InputEvent } from "../../ui/gestures";
+import { type Layer, type LayerContext } from "../../ui/layers";
+import {
+  createInProcessWindow,
+  YieldAtRootLayer,
+  type InProcessAppOptions,
+  type InProcessWindow,
+} from "../../ui/shell/in-process-window";
+import { dailySummary, hypnogram, rollupSeries, type DailySummary } from "../../health/health-derive";
+import {
+  drawGlancePage,
+  GLANCE_PAGES,
+  type GlanceData,
+} from "../../health/health-glance";
+import { healthStore } from "../../health/health-store-files";
+import { requestFreshPull, syncLiveRecords } from "../../health/health-live";
+import { isFixtureData, seedFixturesIfNeeded } from "../../health/health-seed";
+import {
+  DAY_MS,
+  SAMPLE_METRICS,
+  startOfLocalDay,
+  type RollupPoint,
+  type SampleMetric,
+} from "../../health/health-types";
+
+export const HEALTH_WINDOW_ID = "health";
+export const HEALTH_SURFACE_ID = "window:health";
+
+/** Cheap enough to re-read on a timer; the store is a few hundred rows a day. */
+const REFRESH_INTERVAL_MS = 60_000;
+
+class HealthLayer implements Layer {
+  private summary: DailySummary | null = null;
+  /** Today by hour, per metric - what the drill-down pages plot. */
+  private hourly: Partial<Record<SampleMetric, RollupPoint[]>> = {};
+  private stageBands: GlanceData["stageBands"] = [];
+  private fixture = false;
+  /** Index into GLANCE_PAGES. 0 is the overview. */
+  private pageIndex = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private removed = false;
+
+  constructor(private readonly requestRender: () => void) {}
+
+  start(): void {
+    // Live data first: if the ring has been pulled this session, this stores it
+    // and wipes any fixtures out of the way. Only if that leaves us with
+    // nothing does seeding fill the screen, and seeding refuses outright once
+    // real data has ever landed.
+    syncLiveRecords();
+    // Ask for something current rather than showing whatever the last
+    // automatic 30-minute pull happened to catch. Returns immediately; the
+    // pull takes ~15s and lands via the refresh tick below.
+    requestFreshPull();
+    seedFixturesIfNeeded();
+    this.reload();
+    this.timer = setInterval(() => this.reload(), REFRESH_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.removed) return;
+    this.removed = true;
+    if (this.timer !== null) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  onRemoved(): void {
+    this.stop();
+  }
+
+  private reload(): void {
+    if (this.removed) return;
+    // Cheap on every tick: a no-op when the communicator has nothing new, and
+    // the store dedupes when it does, so a 30-minute pull shows up here within
+    // one refresh instead of waiting for the app to be reopened.
+    syncLiveRecords();
+    try {
+      const store = healthStore();
+      const today = startOfLocalDay(Date.now());
+      const samples = store.samplesInRange(today, today + DAY_MS);
+      const sessions = store.sleepSessions();
+      this.summary = dailySummary(samples, sessions, today);
+      // One pass per metric over a day's samples - a few hundred rows, and the
+      // drill-down has to be instant when the cursor lands on it.
+      const hourly: Partial<Record<SampleMetric, RollupPoint[]>> = {};
+      for (const metric of SAMPLE_METRICS) {
+        hourly[metric] = rollupSeries(samples, {
+          metric,
+          granularity: "hour",
+          startMs: today,
+          endMs: today + DAY_MS,
+        });
+      }
+      this.hourly = hourly;
+      const night = sessions.find((session) => session.dayStartMs === today);
+      this.stageBands = night ? hypnogram(night) : [];
+      this.fixture = isFixtureData();
+    } catch (error) {
+      console.warn("health glance reload failed", error);
+    }
+    this.requestRender();
+  }
+
+  paint(ctx: LayerContext): GrayImage {
+    const { width, height } = ctx.stack.getBaseSize();
+    const image = new GrayImage(width, height, 0);
+    drawGlancePage(
+      image,
+      { width, height },
+      { small: getDefaultSmallFont(), large: getDefaultLargeFont() },
+      GLANCE_PAGES[this.pageIndex] ?? GLANCE_PAGES[0]!,
+      {
+        summary: this.summary,
+        hourly: this.hourly,
+        stageBands: this.stageBands,
+        nowMs: Date.now(),
+        fixture: this.fixture,
+      },
+    );
+    return image;
+  }
+
+  /**
+   * Scrolling moves between the overview and the per-parameter detail pages.
+   *
+   * The cursor WRAPS. With seven pages and no back gesture available
+   * (`YieldAtRootLayer` takes double-click for back-out-to-home), wrapping is
+   * what guarantees the overview is always reachable by holding one direction -
+   * a user who has scrolled to the end never has to work out which way is back.
+   * Click advances too, so the drill-down is reachable without ever scrolling.
+   */
+  handleInput(event: InputEvent, _ctx: LayerContext): void {
+    switch (event.type) {
+      case "scroll-down":
+      case "click":
+        this.movePage(1);
+        return;
+      case "scroll-up":
+        this.movePage(-1);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private movePage(delta: number): void {
+    const count = GLANCE_PAGES.length;
+    this.pageIndex = (this.pageIndex + delta + count) % count;
+    this.requestRender();
+  }
+}
+
+export function createHealthAppWindow(options: InProcessAppOptions): InProcessWindow {
+  let requestRender = () => {};
+  const layer = new HealthLayer(() => requestRender());
+  const app = createInProcessWindow({
+    appId: "health",
+    windowId: HEALTH_WINDOW_ID,
+    title: "Health",
+    iconLetter: "H",
+    icon: "activity",
+    closeable: true,
+    actions: options.actions,
+    baseLayer: new YieldAtRootLayer(layer),
+    submitFrame: options.submitFrame,
+    setSurfaceVisible: options.setSurfaceVisible,
+    removeSurface: options.removeSurface,
+    onClosed: () => {
+      layer.stop();
+      options.onClosed();
+    },
+  });
+  requestRender = app.requestRender;
+  layer.start();
+  return app;
+}

--- a/app/apps/health/index.ts
+++ b/app/apps/health/index.ts
@@ -1,0 +1,11 @@
+import { type AppDefinition } from "../app-definition";
+import { createHealthAppWindow, HEALTH_SURFACE_ID, HEALTH_WINDOW_ID } from "./health-app";
+
+const healthApp: AppDefinition = {
+  appId: "health",
+  title: "Health",
+  icon: "activity",
+  launch: (ctx) => ctx.launchInProcessApp(HEALTH_WINDOW_ID, HEALTH_SURFACE_ID, createHealthAppWindow),
+};
+
+export default healthApp;

--- a/app/health/health-chart.ts
+++ b/app/health/health-chart.ts
@@ -1,0 +1,684 @@
+/**
+ * The chart renderer, shared by both surfaces.
+ *
+ * Both the glasses glance and the phone graphs draw into a `GrayImage`, and
+ * the phone converts its one through `grayImageToPreviewSource()` - the same
+ * already-shipping path the glasses mirror uses to put a rendered frame on the
+ * phone screen. That is a deliberate reuse rather than a shortcut: it means
+ * one drawing implementation covers both surfaces, no new native code exists
+ * for the phone side, and the two screens cannot drift apart visually.
+ *
+ * ⚠ DESIGN CHOICE, not a spec (Chris said only "the Even app wasn't bad for
+ * this, I liked their summaries, but we can't copy it, we have to make our
+ * own"): the phone charts are MONOCHROME, because that is what
+ * `PreviewBitmapUtil.fromGray` produces and adding colour would mean new
+ * Kotlin. It lands somewhere deliberate rather than accidental - the phone
+ * already shows the glasses' grey mirror, so the health screens read as part
+ * of the same instrument - but colour is a real option later and would be a
+ * contained change: a second bitmap builder plus a palette here.
+ *
+ * Nothing in this file imports NativeScript, and that is load-bearing rather
+ * than incidental: `tools/health-preview.cjs` renders these functions under
+ * plain node and writes PNGs, so a layout can be looked at without an Android
+ * emulator in the loop. Keep it that way - the fonts arrive as `UiFont`
+ * arguments precisely so no drawing code ever has to reach for the platform.
+ */
+
+import { GrayImage } from "../graphics/image";
+import { type UiFont } from "../graphics/image";
+import {
+  type RollupPoint,
+  type SampleMetric,
+  type SleepNight,
+  isCumulative,
+} from "./health-types";
+import { bandIsMeaningful, formatValue, primaryValue } from "./health-derive";
+import { STAGE_MAPPING_CONFIRMED, type SleepStageName } from "./sleep-stages";
+
+/**
+ * The grey ramp. Everything drawn here uses one of these.
+ *
+ * ⚠ RAISED FOR CONTRAST, 2026-09-10 (Chris, reviewing the first pass): "the
+ * chart axis labels/gridlines are too low-contrast - dark grey on black, hard
+ * to read". The old ramp put gridlines at 42 and axis labels at 148 on a black
+ * plate, which on the phone's dark chart surface left the gridlines essentially
+ * invisible and the numbers a squint. Gridlines, the axis line and label text
+ * all moved up.
+ *
+ * `faint` is new and is where the things that were DELIBERATELY quiet went -
+ * the sample-data badge, the column divider, an unmapped hypnogram block. They
+ * used to share `grid`'s value, so raising `grid` for legibility would have
+ * dragged them up too; splitting the token is what lets the chart get brighter
+ * without the furniture shouting.
+ */
+export const INK = {
+  background: 0,
+  /** Deliberately quiet furniture - badges, dividers, unmapped blocks. */
+  faint: 46,
+  grid: 100,
+  axis: 145,
+  band: 82,
+  bar: 168,
+  line: 250,
+  label: 205,
+  title: 255,
+  dim: 125,
+} as const;
+
+export type ChartRect = { x: number; y: number; width: number; height: number };
+
+export type ChartOptions = {
+  /** Only used to pick the default mode and to read `avg` vs `sum`. */
+  metric: SampleMetric;
+  points: readonly RollupPoint[];
+  font: UiFont;
+  /** Formats a point's x-axis label; return "" to leave a tick unlabelled. */
+  xLabel: (point: RollupPoint, index: number) => string;
+  /**
+   * `band` draws a min/max band with the average through it; `bars` draws a
+   * column per bucket from zero. Defaults to bars for the cumulative metrics.
+   */
+  mode?: "band" | "bars";
+};
+
+/**
+ * A min/max band with the average tracked through it, or bars for the
+ * cumulative metrics.
+ *
+ * Gaps are drawn as gaps. A ring is taken off to charge, so missing hours are
+ * the normal case, not an edge case, and a line that joins across them claims
+ * a continuity the data does not have.
+ */
+export function drawMetricChart(image: GrayImage, rect: ChartRect, options: ChartOptions): void {
+  const { metric, points, font } = options;
+  const labelWidth = Math.max(34, font.measureText("8888") + 6);
+  const labelHeight = font.lineHeight + 2;
+  const plot: ChartRect = {
+    x: rect.x + labelWidth,
+    y: rect.y,
+    width: Math.max(8, rect.width - labelWidth),
+    height: Math.max(8, rect.height - labelHeight),
+  };
+
+  const withData = points.filter((point) => point.count > 0);
+  if (withData.length === 0) {
+    drawNoData(image, rect, font);
+    return;
+  }
+
+  const bars = options.mode ? options.mode === "bars" : isCumulative(metric);
+  const scale = valueScale(withData, bars);
+  const showBand = !bars && bandIsMeaningful(points);
+
+  drawGrid(image, plot, scale, font, rect.x);
+
+  const slotWidth = plot.width / points.length;
+  const yFor = (value: number): number =>
+    plot.y + plot.height - ((value - scale.low) / scale.span) * plot.height;
+
+  if (bars) {
+    const barWidth = Math.max(1, Math.floor(slotWidth * 0.62));
+    for (let index = 0; index < points.length; index += 1) {
+      const point = points[index]!;
+      if (point.count === 0) continue;
+      const top = yFor(point.sum);
+      const left = Math.round(plot.x + index * slotWidth + (slotWidth - barWidth) / 2);
+      const height = Math.max(1, Math.round(plot.y + plot.height - top));
+      image.fillRect(left, Math.round(top), barWidth, height, INK.bar);
+    }
+  } else {
+    if (showBand) {
+      for (let index = 0; index < points.length; index += 1) {
+        const point = points[index]!;
+        if (point.count === 0) continue;
+        const left = Math.round(plot.x + index * slotWidth);
+        const width = Math.max(1, Math.round(slotWidth));
+        const top = Math.round(yFor(point.max));
+        const bottom = Math.round(yFor(point.min));
+        image.fillRect(left, top, width, Math.max(1, bottom - top), INK.band);
+      }
+    }
+    // The average line, drawn only between adjacent points that both have
+    // data, so a gap stays a gap.
+    let previous: { x: number; y: number } | null = null;
+    for (let index = 0; index < points.length; index += 1) {
+      const point = points[index]!;
+      if (point.count === 0) {
+        previous = null;
+        continue;
+      }
+      const cx = plot.x + index * slotWidth + slotWidth / 2;
+      const cy = yFor(primaryValue(point, metric));
+      if (previous) image.drawLine(previous.x, previous.y, cx, cy, INK.line);
+      else image.fillRect(Math.round(cx), Math.round(cy), 1, 1, INK.line);
+      previous = { x: cx, y: cy };
+    }
+  }
+
+  drawXLabels(image, plot, points, font, rect, options.xLabel);
+}
+
+function drawNoData(image: GrayImage, rect: ChartRect, font: UiFont): void {
+  const message = "No data for this range";
+  image.drawText(
+    font,
+    rect.x + Math.round((rect.width - font.measureText(message)) / 2),
+    rect.y + Math.round(rect.height / 2) - font.lineHeight,
+    message,
+    INK.dim,
+  );
+}
+
+/** X labels along the bottom of a plot, thinned so they never collide. */
+function drawXLabels(
+  image: GrayImage,
+  plot: ChartRect,
+  points: readonly { startMs: number }[],
+  font: UiFont,
+  clip: ChartRect,
+  xLabel: (point: never, index: number) => string,
+): void {
+  const slotWidth = plot.width / Math.max(1, points.length);
+  const step = Math.max(1, Math.ceil(46 / Math.max(1, slotWidth)));
+  const labelY = plot.y + plot.height + 2;
+  for (let index = 0; index < points.length; index += step) {
+    const text = xLabel(points[index]! as never, index);
+    if (!text) continue;
+    const cx = plot.x + index * slotWidth + slotWidth / 2;
+    const x = Math.round(cx - font.measureText(text) / 2);
+    if (x < clip.x || x + font.measureText(text) > clip.x + clip.width) continue;
+    image.drawText(font, x, labelY, text, INK.label);
+  }
+}
+
+type Scale = { low: number; high: number; span: number };
+
+function valueScale(points: readonly RollupPoint[], bars: boolean): Scale {
+  let low = Number.POSITIVE_INFINITY;
+  let high = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    const top = bars ? point.sum : point.max;
+    const bottom = bars ? 0 : point.min;
+    if (bottom < low) low = bottom;
+    if (top > high) high = top;
+  }
+  if (!Number.isFinite(low) || !Number.isFinite(high)) return { low: 0, high: 1, span: 1 };
+  if (bars) low = 0;
+  if (high - low < 1) {
+    // A flat series still needs somewhere to sit; centre it rather than
+    // letting it collapse onto the axis.
+    low -= 1;
+    high += 1;
+  }
+  // Bars are measured from zero, so only the top gets breathing room - padding
+  // the bottom too would put a negative tick under a count that cannot go
+  // negative, and float the bars off their own baseline.
+  const pad = (high - low) * 0.08;
+  const scale = { low: bars ? low : low - pad, high: high + pad, span: 0 };
+  scale.span = scale.high - scale.low || 1;
+  return scale;
+}
+
+function drawGrid(
+  image: GrayImage,
+  plot: ChartRect,
+  scale: Scale,
+  font: UiFont,
+  labelX: number,
+): void {
+  const lines = 3;
+  for (let index = 0; index < lines; index += 1) {
+    const fraction = index / (lines - 1);
+    const value = scale.high - fraction * scale.span;
+    const y = Math.round(plot.y + fraction * plot.height);
+    image.drawLine(plot.x, y, plot.x + plot.width, y, INK.grid);
+    const text = `${Math.round(value)}`;
+    const textY = Math.min(
+      plot.y + plot.height - font.lineHeight,
+      Math.max(plot.y, y - Math.round(font.lineHeight / 2)),
+    );
+    image.drawText(font, labelX, textY, text, INK.label);
+  }
+  image.drawLine(plot.x, plot.y, plot.x, plot.y + plot.height, INK.axis);
+}
+
+// ===========================================================================
+// Sleep
+
+/**
+ * Stage inks.
+ *
+ * ⚠ RAISED AND REORDERED, 2026-09-10, alongside the diverging sleep chart.
+ * Within the upward stack the ramp descends with height - deep (bottom) is the
+ * brightest, light (top) the dimmest - so the three read as one column with a
+ * clear internal order rather than three similar greys.
+ *
+ * `wake` is deliberately NOT the dimmest any more, which looks wrong in a list
+ * and is right on the chart: awake time is drawn BELOW the zero line, so it is
+ * separated from the stack spatially rather than by brightness. That frees it
+ * to be legible (Chris's contrast note applies to it as much as to the axes)
+ * without it reading as part of the sleep stack.
+ */
+const STAGE_INK: Readonly<Record<SleepStageName, number>> = {
+  wake: 150,
+  rem: 180,
+  light: 112,
+  deep: 250,
+};
+
+export function stageInk(stage: SleepStageName): number {
+  return STAGE_INK[stage];
+}
+
+/**
+ * The night as a run of stage blocks.
+ *
+ * This is the ONE thing on either surface that depends on the raw stage-id
+ * mapping, so while `STAGE_MAPPING_CONFIRMED` is false the caller is expected
+ * to caption it as unconfirmed - `hypnogramCaption()` supplies the wording.
+ */
+export function drawHypnogram(
+  image: GrayImage,
+  rect: ChartRect,
+  bands: readonly { stage: SleepStageName | null; seconds: number }[],
+): void {
+  let total = 0;
+  for (const band of bands) total += band.seconds;
+  if (total <= 0) return;
+  let x = rect.x;
+  for (const band of bands) {
+    const width = (band.seconds / total) * rect.width;
+    const drawn = Math.max(1, Math.round(width));
+    // An unmapped stage id is drawn as a hatch-dim block rather than being
+    // dropped: the time happened, we just cannot name it.
+    const ink = band.stage ? STAGE_INK[band.stage] : INK.faint;
+    image.fillRect(Math.round(x), rect.y, drawn, rect.height, ink);
+    x += width;
+  }
+  image.drawRect(rect.x, rect.y, rect.width, rect.height, INK.axis);
+}
+
+export function hypnogramCaption(): string {
+  return STAGE_MAPPING_CONFIRMED
+    ? "Sleep stages through the night"
+    : "Stage pattern - labels not yet confirmed on live data";
+}
+
+/** The same caption for the glasses, where the line is 300-odd pixels wide. */
+export function hypnogramCaptionShort(): string {
+  return STAGE_MAPPING_CONFIRMED ? "Stages through the night" : "Stages - labels unconfirmed";
+}
+
+// ===========================================================================
+// The diverging nightly sleep chart (week / month / 3 months)
+
+/**
+ * A night as a DIVERGING stacked bar - Chris's design, 2026-09-10.
+ *
+ * Sleep stacks upward from zero in the order deep (bottom), REM (middle),
+ * light (top). Awake time stacks DOWNWARD, below the zero line, as its own
+ * segment.
+ *
+ * The divergence is the whole idea and it is a claim about the data, not a
+ * styling choice: awake time is not a kind of sleep, so stacking it with the
+ * others would make a restless night's column look like a long one. Putting it
+ * below the line means the upward height is always "how much you slept" and
+ * can be compared across nights at a glance, while the downward tail says what
+ * it cost. A legend names the four, because a monochrome stack is not
+ * self-describing.
+ *
+ * ⚠ The stage ORDER is specified (deep/REM/light bottom-to-top, awake below);
+ * the axis ticks, the 1px separators and the legend placement are mine.
+ */
+/**
+ * The upward stack, BOTTOM TO TOP. Deep is the foundation of the column.
+ *
+ * See `SLEEP_LANE_ORDER` for why this and the lane order only look like they
+ * disagree.
+ */
+export const SLEEP_STACK_ORDER: readonly SleepStageName[] = ["deep", "rem", "light"];
+
+/**
+ * The one-night detail's lanes, TOP TO BOTTOM.
+ *
+ * ⚠ THESE TWO ORDERS LOOK CONTRADICTORY AND ARE NOT. Chris gave both in the
+ * same review, in opposite directions: the week/month chart stacks "Deep
+ * (bottom), REM (middle), light (top)" upward with awake below zero, and the
+ * one-day view lists "Awake, light, REM, Deep" downward. Stated that way they
+ * read as a conflict, which is why the brief flagged the difference as
+ * deliberate rather than a typo.
+ *
+ * Resolve both to the same direction and the conflict disappears. Top to
+ * bottom, the stack is light / REM / deep; top to bottom, the lanes are awake /
+ * light / REM / deep. The three sleep stages are in the SAME vertical order in
+ * both views - deep at the bottom, light nearest the top - so a reader who
+ * learns the arrangement on one screen reads the other correctly without
+ * relearning it.
+ *
+ * The one genuine difference is where awake goes: its own lane above the
+ * others here, its own bar below the zero line there. That follows from what
+ * each view is: a timeline has to show awake in sequence with everything else,
+ * and a stacked total must not add it to the sleep it interrupted.
+ *
+ * A test pins the agreement, so "fixing" either order breaks it loudly.
+ */
+export const SLEEP_LANE_ORDER: readonly SleepStageName[] = ["wake", "light", "rem", "deep"];
+
+/** Descending "nice" ticks for the awake axis, in hours: 4h..5m. */
+const DOWN_TICK_HOURS = [4, 2, 1, 0.5, 0.25, 1 / 6, 1 / 12];
+
+/** "2" for whole hours, "30m" below one - the awake side is usually minutes. */
+function formatHourTick(hours: number): string {
+  return hours >= 1 ? `${hours}` : `${Math.round(hours * 60)}m`;
+}
+
+export function drawSleepStackChart(
+  image: GrayImage,
+  rect: ChartRect,
+  options: {
+    nights: readonly SleepNight[];
+    font: UiFont;
+    xLabel: (night: SleepNight, index: number) => string;
+  },
+): void {
+  const { nights, font } = options;
+  const labelWidth = Math.max(34, font.measureText("-88m") + 6);
+  const legendHeight = font.lineHeight + 4;
+  const labelHeight = font.lineHeight + 2;
+  const plot: ChartRect = {
+    x: rect.x + labelWidth,
+    y: rect.y + legendHeight,
+    width: Math.max(8, rect.width - labelWidth),
+    height: Math.max(8, rect.height - labelHeight - legendHeight),
+  };
+
+  drawStageLegend(image, rect.x, rect.y, rect.width, font);
+
+  const withData = nights.filter((night) => night.hasData);
+  if (withData.length === 0) {
+    drawNoData(image, rect, font);
+    return;
+  }
+
+  const hours = (seconds: number): number => seconds / 3600;
+  let maxUp = 0;
+  let maxDown = 0;
+  for (const night of withData) {
+    const up = hours(night.deepSec + night.remSec + night.lightSec);
+    const down = hours(night.wakeSec);
+    if (up > maxUp) maxUp = up;
+    if (down > maxDown) maxDown = down;
+  }
+  // Headroom above, and a floor under the awake band so a night with almost no
+  // wake time still leaves the zero line off the bottom edge.
+  maxUp = Math.max(1, maxUp * 1.08);
+  maxDown = Math.max(0.5, maxDown * 1.15);
+
+  const span = maxUp + maxDown;
+  const zeroY = Math.round(plot.y + (maxUp / span) * plot.height);
+  const pxPerHour = plot.height / span;
+
+  // Gridlines: whole hours above zero, and one below for the awake side.
+  const upStep = maxUp > 9 ? 4 : maxUp > 4 ? 2 : 1;
+  for (let hour = upStep; hour <= maxUp; hour += upStep) {
+    const y = Math.round(zeroY - hour * pxPerHour);
+    if (y < plot.y) break;
+    image.drawLine(plot.x, y, plot.x + plot.width, y, INK.grid);
+    image.drawText(font, rect.x, y - Math.round(font.lineHeight / 2), `${hour}`, INK.label);
+  }
+  // The awake side needs its own tick ladder, not the hour steps used above.
+  // A typical night is six hours of sleep against ten or twenty minutes awake,
+  // so a whole-hour tick below zero falls off the bottom of the chart and the
+  // downward axis ends up unlabelled - which is what the first cut of this did.
+  const downTick = DOWN_TICK_HOURS.find((hours) => hours <= maxDown * 0.95);
+  if (downTick !== undefined) {
+    const downY = Math.round(zeroY + downTick * pxPerHour);
+    if (downY <= plot.y + plot.height) {
+      image.drawLine(plot.x, downY, plot.x + plot.width, downY, INK.grid);
+      image.drawText(
+        font,
+        rect.x,
+        downY - Math.round(font.lineHeight / 2),
+        `-${formatHourTick(downTick)}`,
+        INK.label,
+      );
+    }
+  }
+
+  const slotWidth = plot.width / nights.length;
+  const barWidth = Math.max(1, Math.floor(slotWidth * 0.68));
+
+  for (let index = 0; index < nights.length; index += 1) {
+    const night = nights[index]!;
+    if (!night.hasData) continue;
+    const left = Math.round(plot.x + index * slotWidth + (slotWidth - barWidth) / 2);
+
+    // Upward: deep at the bottom, then REM, then light. Drawn from the zero
+    // line outward so rounding never opens a gap at the baseline.
+    let cursor = zeroY;
+    const secondsByStage: Record<SleepStageName, number> = {
+      deep: night.deepSec,
+      rem: night.remSec,
+      light: night.lightSec,
+      wake: night.wakeSec,
+    };
+    const upward: [number, number][] = SLEEP_STACK_ORDER.map((stage) => [
+      secondsByStage[stage],
+      STAGE_INK[stage],
+    ]);
+    for (const [seconds, ink] of upward) {
+      if (seconds <= 0) continue;
+      const height = Math.max(1, Math.round(hours(seconds) * pxPerHour));
+      const top = Math.max(plot.y, cursor - height);
+      image.fillRect(left, top, barWidth, Math.max(1, cursor - top), ink);
+      cursor = top;
+      // A 1px unlit separator so two adjacent greys stay two segments. Only
+      // worth it when the bar is tall enough to still read as a block.
+      if (cursor > plot.y + 1 && height > 3) {
+        image.fillRect(left, cursor, barWidth, 1, INK.background);
+      }
+    }
+
+    // Downward: awake, below the line.
+    if (night.wakeSec > 0) {
+      const height = Math.max(1, Math.round(hours(night.wakeSec) * pxPerHour));
+      const bottom = Math.min(plot.y + plot.height, zeroY + 1 + height);
+      image.fillRect(left, zeroY + 1, barWidth, Math.max(1, bottom - zeroY - 1), STAGE_INK.wake);
+    }
+  }
+
+  // The zero line last, so it sits on top of every bar that touches it - it is
+  // the reference the whole chart is read against.
+  image.drawLine(plot.x, zeroY, plot.x + plot.width, zeroY, INK.axis);
+  image.drawText(font, rect.x, zeroY - Math.round(font.lineHeight / 2), "0", INK.label);
+  image.drawLine(plot.x, plot.y, plot.x, plot.y + plot.height, INK.axis);
+
+  drawXLabels(
+    image,
+    { ...plot, y: plot.y, height: plot.height },
+    nights,
+    font,
+    { ...rect, y: plot.y, height: plot.height },
+    ((night: SleepNight, index: number) => options.xLabel(night, index)) as never,
+  );
+}
+
+/**
+ * The four stages as swatch + name, on one line.
+ *
+ * Awake is listed last and marked, because its bar goes the other way and a
+ * legend that reads deep/REM/light/awake in a row would imply they stack
+ * together.
+ */
+export function drawStageLegend(
+  image: GrayImage,
+  x: number,
+  y: number,
+  width: number,
+  font: UiFont,
+): void {
+  const entries: [string, number][] = [
+    ["Deep", STAGE_INK.deep],
+    ["REM", STAGE_INK.rem],
+    ["Light", STAGE_INK.light],
+    ["Awake v", STAGE_INK.wake],
+  ];
+  const swatch = Math.max(6, font.lineHeight - 4);
+  let cursor = x;
+  for (const [label, ink] of entries) {
+    const textWidth = font.measureText(label);
+    const entryWidth = swatch + 4 + textWidth + 12;
+    if (cursor + entryWidth > x + width) break;
+    image.fillRect(cursor, y + 2, swatch, swatch, ink);
+    image.drawRect(cursor, y + 2, swatch, swatch, INK.axis);
+    image.drawText(font, cursor + swatch + 4, y, label, INK.label);
+    cursor += entryWidth;
+  }
+}
+
+// ===========================================================================
+// The one-night sleep detail (the glasses drill-down)
+
+/**
+ * One night as four horizontal LANES, stacked top to bottom in the order
+ * Awake, Light, REM, Deep - Chris's ordering, 2026-09-10. It is stated in the
+ * opposite direction from the week chart's and therefore reads as a conflict
+ * with it; it is not one, and `SLEEP_LANE_ORDER` explains why. Both views put
+ * deep at the bottom.
+ *
+ * ⚠ PROPORTIONS ARE A DESIGN CALL. The stage order and the top-to-bottom
+ * orientation are specified; "exactly what arranged vertically should look
+ * like pixel-for-pixel wasn't specified further than that ordering". So: four
+ * equal-height lanes across the full width of the night, each lane's blocks
+ * filled where the sleeper was in that stage, with the lane's name and its
+ * total on the left. Equal heights rather than height-proportional-to-duration,
+ * because the lane's JOB is to show when that stage happened, and a 4%-of-night
+ * deep lane squeezed to a few pixels would show nothing.
+ */
+export function drawSleepLanes(
+  image: GrayImage,
+  rect: ChartRect,
+  options: {
+    bands: readonly { stage: SleepStageName | null; seconds: number }[];
+    font: UiFont;
+    /** Left-column label + total for each lane, in lane order. */
+    laneText: (stage: SleepStageName) => { label: string; value: string };
+  },
+): void {
+  const { bands, font } = options;
+  const LANE_ORDER = SLEEP_LANE_ORDER;
+
+  let total = 0;
+  for (const band of bands) total += band.seconds;
+  if (total <= 0) {
+    drawNoData(image, rect, font);
+    return;
+  }
+
+  // The left column has to fit "Awake" plus its duration; measure rather than
+  // guess, so a larger UI font does not overrun the lanes.
+  let gutter = 0;
+  for (const stage of LANE_ORDER) {
+    const text = options.laneText(stage);
+    gutter = Math.max(gutter, font.measureText(text.label), font.measureText(text.value));
+  }
+  gutter += 10;
+
+  const laneX = rect.x + gutter;
+  const laneWidth = Math.max(8, rect.width - gutter);
+  const axisHeight = font.lineHeight + 2;
+  const laneGap = 4;
+  const laneHeight = Math.max(
+    6,
+    Math.floor((rect.height - axisHeight - laneGap * (LANE_ORDER.length - 1)) / LANE_ORDER.length),
+  );
+
+  for (let index = 0; index < LANE_ORDER.length; index += 1) {
+    const stage = LANE_ORDER[index]!;
+    const top = rect.y + index * (laneHeight + laneGap);
+    const text = options.laneText(stage);
+
+    // The lane's own track, so an empty stretch still reads as a lane rather
+    // than as nothing.
+    image.drawRect(laneX, top, laneWidth, laneHeight, INK.faint);
+
+    let cursor = laneX;
+    for (const band of bands) {
+      const width = (band.seconds / total) * laneWidth;
+      if (band.stage === stage) {
+        image.fillRect(Math.round(cursor), top, Math.max(1, Math.round(width)), laneHeight, STAGE_INK[stage]);
+      }
+      cursor += width;
+    }
+
+    // Name above its own duration, both in the gutter, vertically centred on
+    // the lane when there is room for two lines.
+    const twoLines = laneHeight >= font.lineHeight * 2;
+    const textTop = twoLines
+      ? top + Math.round((laneHeight - font.lineHeight * 2) / 2)
+      : top + Math.round((laneHeight - font.lineHeight) / 2);
+    image.drawText(font, rect.x, textTop, text.label, INK.label);
+    if (twoLines) image.drawText(font, rect.x, textTop + font.lineHeight, text.value, INK.line);
+  }
+
+  // A time axis under the lanes: the night runs left to right, so mark its
+  // ends. Without this the lanes are a proportion with no anchor.
+  const axisY = rect.y + LANE_ORDER.length * (laneHeight + laneGap);
+  image.drawLine(laneX, axisY, laneX + laneWidth, axisY, INK.axis);
+}
+
+// ===========================================================================
+// Small shared pieces
+
+/**
+ * A "min / avg / max" readout, the shape both surfaces use for a metric.
+ *
+ * `whole` rounds all three. The glance passes it: an average heart rate
+ * printed as 72.7 reads as precision the measurement does not have, and on a
+ * screen you glance at rather than study, the tenth is noise. The phone's stat
+ * panel keeps the decimal, where comparing two averages is the point.
+ */
+export function tripleText(
+  summary: { min: number; max: number; avg: number; hasData: boolean },
+  metric: SampleMetric,
+  options?: { whole?: boolean },
+): string {
+  if (!summary.hasData) return "--";
+  const show = (value: number): string =>
+    options?.whole ? `${Math.round(value)}` : formatValue(value, metric);
+  return `${show(summary.min)} / ${show(summary.avg)} / ${show(summary.max)}`;
+}
+
+/**
+ * "60-98 bpm, avg 73" - the glance's metric line.
+ *
+ * ⚠ REPLACES the min/avg/max triple on the glasses overview, Chris 2026-09-10:
+ * three bare numbers under a "min / avg / max" legend made the reader do the
+ * decoding. A range and an average is the same information said in the shape a
+ * person would say it in, and it needs no legend line underneath.
+ *
+ * The separator is an ASCII hyphen, not an en dash: the glasses render through
+ * Terminus, and a codepoint the face does not carry comes back as the default
+ * char - a "?" in the middle of the number - rather than failing loudly.
+ */
+export function rangeAverageText(
+  summary: { min: number; max: number; avg: number; hasData: boolean },
+  unit: string,
+): string {
+  if (!summary.hasData) return "--";
+  const whole = (value: number): string => `${Math.round(value)}`;
+  const range = `${whole(summary.min)}-${whole(summary.max)}`;
+  return unit ? `${range} ${unit}, avg ${whole(summary.avg)}` : `${range}, avg ${whole(summary.avg)}`;
+}
+
+/** A right-aligned draw, for readouts that should line up on their last digit. */
+export function drawTextRight(
+  image: GrayImage,
+  font: UiFont,
+  right: number,
+  y: number,
+  text: string,
+  value: number,
+): void {
+  image.drawText(font, Math.round(right - font.measureText(text)), y, text, value);
+}

--- a/app/health/health-derive.ts
+++ b/app/health/health-derive.ts
@@ -1,0 +1,406 @@
+/**
+ * Every derived number the two health surfaces show, in one place, with no
+ * NativeScript imports so it runs under plain node in `tests/`.
+ *
+ * The rule this file follows throughout: show what the ring actually said, or
+ * say we do not know. Nothing here invents a value to fill a gap, and the one
+ * composite score a health app is expected to have - a 0-100 "sleep quality" -
+ * is deliberately absent. See `sleepSummary` for why.
+ */
+
+import {
+  DAY_MS,
+  HOUR_MS,
+  type HealthSample,
+  type Rollup,
+  type RollupPoint,
+  type SampleMetric,
+  type SleepNight,
+  type SleepSession,
+  isCumulative,
+  rollupOf,
+  startOfLocalDay,
+  startOfLocalHour,
+} from "./health-types";
+import { STAGE_DISPLAY_ORDER, type SleepStageName, stageNameForId } from "./sleep-stages";
+
+export type Granularity = "hour" | "day";
+
+/** How far back a chart looks. Hour granularity only makes sense within a day. */
+export type RangeKey = "day" | "week" | "month" | "quarter";
+
+export const RANGE_DAYS: Readonly<Record<RangeKey, number>> = {
+  day: 1,
+  week: 7,
+  month: 30,
+  quarter: 90,
+};
+
+export const RANGE_LABELS: Readonly<Record<RangeKey, string>> = {
+  day: "Day",
+  week: "Week",
+  month: "Month",
+  quarter: "3 months",
+};
+
+/**
+ * Bucket samples into a series of rollups on a fixed grid.
+ *
+ * The grid is built first and then filled, so a window with no data comes back
+ * as a gap (`count === 0`) at its real position rather than being silently
+ * dropped - a chart that closes over its gaps lies about continuity, which for
+ * a ring that is taken off to charge is the common case, not an edge case.
+ */
+export function rollupSeries(
+  samples: readonly HealthSample[],
+  options: {
+    metric: SampleMetric;
+    granularity: Granularity;
+    /** Inclusive local start of the plotted window. */
+    startMs: number;
+    /** Exclusive local end. */
+    endMs: number;
+  },
+): RollupPoint[] {
+  const { metric, granularity, startMs, endMs } = options;
+  const spanMs = granularity === "hour" ? HOUR_MS : DAY_MS;
+  const align = granularity === "hour" ? startOfLocalHour : startOfLocalDay;
+
+  const buckets = new Map<number, HealthSample[]>();
+  for (const sample of samples) {
+    if (sample.metric !== metric) continue;
+    if (sample.startMs < startMs || sample.startMs >= endMs) continue;
+    const key = align(sample.startMs);
+    const list = buckets.get(key);
+    if (list) list.push(sample);
+    else buckets.set(key, [sample]);
+  }
+
+  const points: RollupPoint[] = [];
+  // Walk by calendar step rather than adding spanMs, so a DST change does not
+  // shift every later bucket by an hour.
+  let cursor = align(startMs);
+  let guard = 0;
+  while (cursor < endMs && guard < 4000) {
+    guard += 1;
+    const inBucket = buckets.get(cursor) ?? [];
+    const rolled = rollupOf(inBucket);
+    points.push({
+      startMs: cursor,
+      spanMs,
+      ...(rolled ?? { min: 0, max: 0, avg: 0, sum: 0, count: 0 }),
+    });
+    cursor = nextBucketStart(cursor, granularity);
+  }
+  return points;
+}
+
+function nextBucketStart(startMs: number, granularity: Granularity): number {
+  const date = new Date(startMs);
+  if (granularity === "hour") date.setHours(date.getHours() + 1, 0, 0, 0);
+  else date.setDate(date.getDate() + 1);
+  return date.getTime();
+}
+
+/** The value a chart plots as "the" line for a metric. */
+export function primaryValue(point: Rollup, metric: SampleMetric): number {
+  return isCumulative(metric) ? point.sum : point.avg;
+}
+
+// ===========================================================================
+// The glasses status page's numbers
+
+export type MetricSummary = {
+  min: number;
+  max: number;
+  avg: number;
+  /** False when nothing was recorded - the UI shows a dash, not a zero. */
+  hasData: boolean;
+};
+
+export type DailySummary = {
+  dayStartMs: number;
+  steps: number;
+  calories: number;
+  heartRate: MetricSummary;
+  spo2: MetricSummary;
+  /**
+   * ⚠ ADDED 2026-09-10. The first pass left HRV off the glance because Chris's
+   * original spec listed steps/calories/HR/SpO2/sleep and nothing else, and the
+   * return doc flagged the absence as deliberate rather than an oversight. He
+   * revised the spec on review: HRV gets a line alongside the others.
+   */
+  hrv: MetricSummary;
+  sleep: SleepSummary | null;
+};
+
+const NO_DATA: MetricSummary = { min: 0, max: 0, avg: 0, hasData: false };
+
+function summarise(samples: readonly HealthSample[], metric: SampleMetric): MetricSummary {
+  const rolled = rollupOf(samples.filter((sample) => sample.metric === metric));
+  if (!rolled) return NO_DATA;
+  return { min: rolled.min, max: rolled.max, avg: rolled.avg, hasData: true };
+}
+
+function sumOf(samples: readonly HealthSample[], metric: SampleMetric): number {
+  let total = 0;
+  for (const sample of samples) if (sample.metric === metric) total += sample.total;
+  return total;
+}
+
+/**
+ * Everything the glasses glance shows, for one local day.
+ *
+ * `sleepSessions` is searched for the night that ENDED on this day - the
+ * "last night's sleep" a morning glance means. A session is attributed to its
+ * wake-up day on ingest (`SleepSession.dayStartMs`), so this is a lookup, not
+ * a heuristic applied here.
+ */
+export function dailySummary(
+  samples: readonly HealthSample[],
+  sleepSessions: readonly SleepSession[],
+  dayStartMs: number,
+): DailySummary {
+  const dayEndMs = nextBucketStart(dayStartMs, "day");
+  const inDay = samples.filter(
+    (sample) => sample.startMs >= dayStartMs && sample.startMs < dayEndMs,
+  );
+  const night = sleepSessions
+    .filter((session) => session.dayStartMs === dayStartMs)
+    .sort((a, b) => b.totalSec - a.totalSec)[0];
+  return {
+    dayStartMs,
+    steps: Math.round(sumOf(inDay, "steps")),
+    calories: Math.round(sumOf(inDay, "calories")),
+    heartRate: summarise(inDay, "heartRate"),
+    spo2: summarise(inDay, "spo2"),
+    hrv: summarise(inDay, "hrv"),
+    sleep: night ? sleepSummary(night) : null,
+  };
+}
+
+// ===========================================================================
+// Sleep
+
+export type SleepSummary = {
+  totalSec: number;
+  /** Whole hours and remaining minutes of `totalSec`, for "6h 42m". */
+  hours: number;
+  minutes: number;
+  wakeSec: number;
+  /** Percentages OF TOTAL SLEEP TIME, from the record's named totals. */
+  remPercent: number;
+  lightPercent: number;
+  deepPercent: number;
+  /**
+   * `total_time / (total_time + wake_time)`, as a percentage.
+   *
+   * This is sleep efficiency as the AASM's actigraphy scoring defines it -
+   * time asleep over time in bed - and it is a decades-old published standard,
+   * not something invented here. It is the one number added beyond Chris's
+   * stated spec, and it is included precisely because it is the opposite of
+   * the thing that was ruled out: it has a definition anyone can look up.
+   *
+   * Deliberately NOT here: a single 0-100 "sleep quality" score. Every
+   * consumer wearable has one, none of them publish the blend, and there is no
+   * generally-accepted formula - so it would be a number with the authority of
+   * a measurement and the content of an opinion. Stage percentages and
+   * efficiency are shown as themselves instead.
+   */
+  efficiencyPercent: number;
+  /** Hypnogram bands, in display order. Empty when the record had no segments. */
+  stageBands: readonly SleepStageBand[];
+  /** False when the session could not be anchored to real wall-clock time. */
+  timeResolved: boolean;
+};
+
+export type SleepStageBand = {
+  stage: SleepStageName;
+  seconds: number;
+  /** Share of total-time-in-bed (sleep + wake), so the bands sum to 100%. */
+  percentOfBed: number;
+};
+
+export function sleepSummary(session: SleepSession): SleepSummary {
+  const total = Math.max(0, session.totalSec);
+  const wake = Math.max(0, session.wakeSec);
+  const inBed = total + wake;
+  const pctOfSleep = (value: number): number => (total > 0 ? (value / total) * 100 : 0);
+  const bedSeconds: Record<SleepStageName, number> = {
+    wake,
+    rem: Math.max(0, session.remSec),
+    light: Math.max(0, session.lightSec),
+    deep: Math.max(0, session.deepSec),
+  };
+  return {
+    totalSec: total,
+    hours: Math.floor(total / 3600),
+    minutes: Math.round((total % 3600) / 60),
+    wakeSec: wake,
+    remPercent: pctOfSleep(session.remSec),
+    lightPercent: pctOfSleep(session.lightSec),
+    deepPercent: pctOfSleep(session.deepSec),
+    efficiencyPercent: inBed > 0 ? (total / inBed) * 100 : 0,
+    stageBands: STAGE_DISPLAY_ORDER.map((stage) => ({
+      stage,
+      seconds: bedSeconds[stage],
+      percentOfBed: inBed > 0 ? (bedSeconds[stage] / inBed) * 100 : 0,
+    })),
+    timeResolved: session.timeResolved,
+  };
+}
+
+/**
+ * One stage's seconds, from the summary's own bands.
+ *
+ * Both surfaces label a stage lane with its duration, and both must take that
+ * number from the record's NAMED per-stage fields (which `sleepSummary` already
+ * resolved into `stageBands`) rather than by summing the hypnogram's blocks.
+ * The two should agree; when they do not it is the segment array that is
+ * suspect, because summing blocks depends on the stage-id mapping and the named
+ * fields do not. See `sleep-stages.ts`.
+ */
+export function stageSeconds(stage: SleepStageName, summary: SleepSummary): number {
+  return summary.stageBands.find((band) => band.stage === stage)?.seconds ?? 0;
+}
+
+/**
+ * One entry per day in the window, carrying that night's four stage totals.
+ *
+ * Built for the diverging nightly chart (deep/REM/light stacked up, awake
+ * down). Like `rollupSeries`, the grid is laid out first and then filled, so a
+ * night with no record comes back as `hasData: false` at its real position
+ * rather than shifting every later night one column left.
+ *
+ * Two sessions attributed to the same day are SUMMED rather than the longest
+ * winning. That differs from `dailySummary`, which picks the longest because it
+ * is answering "how did you sleep last night" with one headline number; here
+ * the column is the day's total time in each stage, and dropping a nap would
+ * make the bar disagree with the sleep total shown beside it.
+ */
+export function sleepNights(
+  sessions: readonly SleepSession[],
+  startMs: number,
+  endMs: number,
+): SleepNight[] {
+  const byDay = new Map<number, SleepNight>();
+  for (const session of sessions) {
+    if (session.dayStartMs < startMs || session.dayStartMs >= endMs) continue;
+    const entry = byDay.get(session.dayStartMs) ?? {
+      startMs: session.dayStartMs,
+      hasData: true,
+      deepSec: 0,
+      remSec: 0,
+      lightSec: 0,
+      wakeSec: 0,
+    };
+    entry.deepSec += Math.max(0, session.deepSec);
+    entry.remSec += Math.max(0, session.remSec);
+    entry.lightSec += Math.max(0, session.lightSec);
+    entry.wakeSec += Math.max(0, session.wakeSec);
+    byDay.set(session.dayStartMs, entry);
+  }
+
+  const nights: SleepNight[] = [];
+  let cursor = startOfLocalDay(startMs);
+  let guard = 0;
+  while (cursor < endMs && guard < 4000) {
+    guard += 1;
+    nights.push(
+      byDay.get(cursor) ?? {
+        startMs: cursor,
+        hasData: false,
+        deepSec: 0,
+        remSec: 0,
+        lightSec: 0,
+        wakeSec: 0,
+      },
+    );
+    cursor = nextBucketStart(cursor, "day");
+  }
+  return nights;
+}
+
+/**
+ * The hypnogram: the night as a run of stage blocks, in order.
+ *
+ * This is the ONE thing that depends on the raw stage-id mapping, which is why
+ * it is separated from `sleepSummary`'s percentages (those come from named
+ * fields and are unaffected). A segment whose id is not in the mapping is
+ * returned with `stage: null` rather than dropped or guessed at.
+ */
+export function hypnogram(session: SleepSession): { stage: SleepStageName | null; seconds: number }[] {
+  return session.segments.map((segment) => ({
+    stage: stageNameForId(segment.stageId),
+    seconds: segment.halfMinutes * 30,
+  }));
+}
+
+/**
+ * Date formatting, done by hand.
+ *
+ * ⚠ MEASURED, not a preference: `toLocaleDateString(undefined, { weekday:
+ * "short" })` in this NativeScript Android runtime IGNORES the options bag and
+ * returns the full `Fri Sep 04 2026`. It is the usual cause - a JS engine
+ * built without full ICU quietly falls back instead of failing - and it turned
+ * a week chart's axis into seven overlapping full dates. Anything that needs a
+ * specific date shape has to build it, so these are the only date formatters
+ * either surface uses.
+ *
+ * The cost is that they are English-only. That is a real limitation and the
+ * right place to fix it is the runtime's ICU, not here.
+ */
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+] as const;
+
+/** "Fri". */
+export function shortWeekday(ms: number): string {
+  return WEEKDAYS[new Date(ms).getDay()] ?? "";
+}
+
+/** "Thu 10 Sep". */
+export function shortDate(ms: number): string {
+  const date = new Date(ms);
+  return `${WEEKDAYS[date.getDay()]} ${date.getDate()} ${MONTHS[date.getMonth()]}`;
+}
+
+/** "6h 42m", or "--" when there is nothing to show. */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "--";
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.round((seconds % 3600) / 60);
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+/** One decimal at most, and never a trailing ".0". */
+export function formatValue(value: number, metric: SampleMetric): string {
+  if (!Number.isFinite(value)) return "--";
+  if (isCumulative(metric)) return `${Math.round(value)}`;
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+}
+
+/**
+ * Whether a metric's min/max band is worth drawing.
+ *
+ * Measured against the real export before this was written: heart rate's
+ * hourly min and max differ in 98% of buckets, but SpO2's and HRV's are
+ * IDENTICAL in 97% of them - the ring reports what amounts to a single reading
+ * per hour for those two. Drawing a band there produces a hairline that reads
+ * as a rendering fault rather than as "there is no spread", so the charts drop
+ * to a plain line when the spread is degenerate across the window.
+ */
+export function bandIsMeaningful(points: readonly RollupPoint[]): boolean {
+  let withData = 0;
+  let withSpread = 0;
+  for (const point of points) {
+    if (point.count === 0) continue;
+    withData += 1;
+    if (point.max > point.min) withSpread += 1;
+  }
+  if (withData === 0) return false;
+  return withSpread / withData >= 0.25;
+}

--- a/app/health/health-fixtures.ts
+++ b/app/health/health-fixtures.ts
@@ -1,0 +1,246 @@
+/**
+ * SAMPLE DATA. Not a capture, not anybody's health history.
+ *
+ * Every number below is generated from a seeded PRNG against hand-written
+ * ranges. Nothing here was copied out of an export. What WAS taken from the
+ * real export - by reading it, which is all this needed - is the *shape*:
+ *
+ *   - heart rate, SpO2 and HRV arrive as HOURLY buckets carrying (avg, max,
+ *     min); steps and calories as TEN-MINUTE buckets; sleep once per session.
+ *   - heart rate's hourly min and max genuinely differ (they were equal in
+ *     about 2% of real buckets), but SpO2's and HRV's are equal in about 97%
+ *     of theirs - the ring effectively reports one reading an hour for those
+ *     two. The generator reproduces that, because a chart that assumes a
+ *     spread everywhere looks broken on the two metrics that do not have one.
+ *   - roughly a third of a day's ten-minute step buckets are non-zero; the
+ *     rest are flat, because people sit still.
+ *   - a night is a handful of hours with a majority in light sleep, a smaller
+ *     REM share, a smaller deep share again, and a short wake total.
+ *
+ * The ranges are round numbers chosen to sit in the same neighbourhood as
+ * those shapes, not measured constants, and the seed is fixed so a screenshot
+ * taken today matches one taken next week.
+ *
+ * `seedFixtures()` also drops a marker file, and both surfaces show a "Sample
+ * data" badge whenever it is present - so a screenshot of this can never be
+ * mistaken later for a screenshot of a real sync.
+ */
+
+import {
+  DAY_MS,
+  HOUR_MS,
+  TEN_MINUTES_MS,
+  type HealthSample,
+  type SleepSession,
+  type SleepSegment,
+  startOfLocalDay,
+} from "./health-types";
+
+/** Bumped whenever the generator changes, so a reseed replaces old fixtures. */
+export const FIXTURE_VERSION = 1;
+
+/** Deterministic, tiny, and good enough for plausible-looking noise. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function between(random: () => number, low: number, high: number): number {
+  return low + random() * (high - low);
+}
+
+/**
+ * A daily activity curve: near-nothing overnight, a morning rise, a dip after
+ * lunch, an evening peak. Returns roughly 0..1 for an hour of the day.
+ */
+function activityCurve(hour: number): number {
+  if (hour < 6) return 0.03;
+  if (hour < 9) return 0.45;
+  if (hour < 12) return 0.7;
+  if (hour < 14) return 0.5;
+  if (hour < 18) return 0.75;
+  if (hour < 21) return 0.9;
+  return 0.25;
+}
+
+export type Fixtures = {
+  samples: HealthSample[];
+  sleep: SleepSession[];
+};
+
+/**
+ * Generate `days` days of sample data ending with today (partially filled up
+ * to `nowMs`, so "today so far" looks like a day in progress rather than a
+ * complete one).
+ */
+export function buildFixtures(options: { days: number; nowMs: number; seed?: number }): Fixtures {
+  const { days, nowMs } = options;
+  const random = mulberry32(options.seed ?? 0x5eed);
+  const samples: HealthSample[] = [];
+  const sleep: SleepSession[] = [];
+  const today = startOfLocalDay(nowMs);
+
+  for (let dayOffset = days - 1; dayOffset >= 0; dayOffset -= 1) {
+    const dayStart = startOfLocalDay(today - dayOffset * DAY_MS);
+    // A per-day baseline so consecutive days are not interchangeable.
+    const restingBase = between(random, 56, 66);
+    const hrvBase = between(random, 32, 55);
+    const spo2Base = between(random, 96, 98);
+
+    for (let hour = 0; hour < 24; hour += 1) {
+      const bucketStart = dayStart + hour * HOUR_MS;
+      if (bucketStart > nowMs) break;
+      const effort = activityCurve(hour);
+
+      // Heart rate: a real spread every hour.
+      const avg = restingBase + effort * between(random, 10, 34);
+      const spread = 4 + effort * between(random, 6, 26);
+      samples.push({
+        metric: "heartRate",
+        startMs: bucketStart,
+        spanMs: HOUR_MS,
+        min: Math.round(avg - spread * between(random, 0.35, 0.6)),
+        max: Math.round(avg + spread * between(random, 0.5, 0.9)),
+        avg: Math.round(avg),
+        total: Math.round(avg),
+      });
+
+      // SpO2 and HRV: one reading an hour most of the time, so min == max.
+      const spo2 = Math.round(spo2Base + between(random, -2, 1.4));
+      const spo2Flat = random() < 0.97;
+      samples.push({
+        metric: "spo2",
+        startMs: bucketStart,
+        spanMs: HOUR_MS,
+        min: spo2Flat ? spo2 : spo2 - 1,
+        max: spo2Flat ? spo2 : spo2 + 1,
+        avg: spo2,
+        total: spo2,
+      });
+
+      const hrv = Math.round(Math.max(6, hrvBase + between(random, -14, 18) - effort * 8));
+      const hrvFlat = random() < 0.97;
+      samples.push({
+        metric: "hrv",
+        startMs: bucketStart,
+        spanMs: HOUR_MS,
+        min: hrvFlat ? hrv : Math.max(2, hrv - 4),
+        max: hrvFlat ? hrv : hrv + 5,
+        avg: hrv,
+        total: hrv,
+      });
+
+      // Steps and calories: six ten-minute buckets inside this hour.
+      for (let slot = 0; slot < 6; slot += 1) {
+        const bucket = bucketStart + slot * TEN_MINUTES_MS;
+        if (bucket > nowMs) break;
+        const moving = random() < effort * 0.55;
+        const steps = moving ? Math.round(between(random, 20, 430) * effort) : 0;
+        const resting = Math.round(between(random, 10, 13));
+        const active = Math.round(steps * between(random, 0.03, 0.05));
+        samples.push({
+          metric: "steps",
+          startMs: bucket,
+          spanMs: TEN_MINUTES_MS,
+          min: steps,
+          max: steps,
+          avg: steps,
+          total: steps,
+        });
+        samples.push({
+          metric: "calories",
+          startMs: bucket,
+          spanMs: TEN_MINUTES_MS,
+          min: resting + active,
+          max: resting + active,
+          avg: resting + active,
+          total: resting + active,
+        });
+      }
+    }
+
+    sleep.push(buildNight(random, dayStart));
+  }
+
+  return { samples, sleep };
+}
+
+/**
+ * One night, attributed to the morning it ended on (`dayStart`).
+ *
+ * Built SEGMENTS FIRST, then the five duration totals summed out of them -
+ * the same direction a real record is consistent in. The decode found four
+ * arithmetic identities holding exactly on every real session, including
+ * `sum(half_minutes) * 30 == total_time + wake_time` and a per-stage sum
+ * matching each named total. Generating the totals first and the segments
+ * afterwards cannot satisfy those exactly once rounding is involved, so this
+ * goes the other way and the identities hold by construction.
+ */
+function buildNight(random: () => number, dayStart: number): SleepSession {
+  const inBedHalfMinutes = Math.round(between(random, 4.4, 6.6) * 120);
+  const bedMs = dayStart - inBedHalfMinutes * 30 * 1000;
+  const segments = buildSegments(random, inBedHalfMinutes);
+
+  const perStage = new Map<number, number>();
+  for (const segment of segments) {
+    perStage.set(segment.stageId, (perStage.get(segment.stageId) ?? 0) + segment.halfMinutes);
+  }
+  const seconds = (stageId: number): number => (perStage.get(stageId) ?? 0) * 30;
+  const wakeSec = seconds(0);
+  const remSec = seconds(1);
+  const lightSec = seconds(2);
+  const deepSec = seconds(3);
+  const totalSec = remSec + lightSec + deepSec;
+
+  return {
+    dayStartMs: dayStart,
+    startMs: bedMs,
+    endMs: bedMs + (totalSec + wakeSec) * 1000,
+    totalSec,
+    wakeSec,
+    remSec,
+    lightSec,
+    deepSec,
+    segments,
+    timeResolved: true,
+  };
+}
+
+/**
+ * A segment run filling exactly `inBedHalfMinutes`, cycling through the stages
+ * the way a night does: light, deep, light, REM, and the occasional wake block.
+ *
+ * Stage ids are the RAW ring ids (0 wake, 1 REM, 2 light, 3 deep). The fixture
+ * deliberately emits ids rather than friendly names, so anything downstream
+ * that forgets to resolve them through `stageNameForId` is wrong here too.
+ *
+ * The per-stage weights are what produce a plausible mix - light dominant,
+ * then deep, then REM, with a small wake share - matching the ordering the
+ * real export shows without reproducing its numbers.
+ */
+function buildSegments(random: () => number, inBedHalfMinutes: number): SleepSegment[] {
+  const cycle = [2, 3, 2, 1, 2, 0];
+  const typicalLength: Record<number, [number, number]> = {
+    0: [1, 6],
+    1: [8, 26],
+    2: [14, 40],
+    3: [10, 30],
+  };
+  const segments: SleepSegment[] = [];
+  let remaining = inBedHalfMinutes;
+  let index = 0;
+  while (remaining > 0) {
+    const stage = cycle[index % cycle.length]!;
+    index += 1;
+    const [low, high] = typicalLength[stage]!;
+    const take = Math.min(remaining, Math.max(1, Math.round(between(random, low, high))));
+    segments.push({ stageId: stage, halfMinutes: take });
+    remaining -= take;
+  }
+  return segments;
+}

--- a/app/health/health-glance.ts
+++ b/app/health/health-glance.ts
@@ -1,0 +1,507 @@
+/**
+ * HEALTH, the glasses surface - all of its DRAWING, and none of its plumbing.
+ *
+ * ## Why this is a separate file from `apps/health/health-app.ts`
+ *
+ * The app file owns the things only a running app can do: reading the store,
+ * the refresh timer, the input cursor, the window lifecycle. All of that needs
+ * NativeScript. The drawing needs nothing but a `GrayImage` and two fonts.
+ *
+ * Splitting them the way `health-store.ts` is split from `health-store-files.ts`
+ * buys the same thing it bought there: this file runs under plain node. That is
+ * what lets `tools/health-preview.cjs` render every one of these pages to a PNG
+ * with no emulator, no AVD and no device - the previews come out of the REAL
+ * paint code, so they cannot drift from what the glasses show the way a
+ * separate mockup can. The first pass verified its layout by booting a full
+ * Android emulator; this file is the reason that is no longer necessary.
+ *
+ * So the rule for this file: fonts and data arrive as arguments, nothing is
+ * imported from `native/` or `@nativescript/core`, and nothing reaches for a
+ * clock except through `data.nowMs`.
+ */
+
+import { GrayImage, type UiFont } from "../graphics/image";
+import { lineStep } from "../ui/metrics";
+import { GESTURE_SCROLL } from "../ui/gestures";
+import {
+  drawSleepLanes,
+  drawMetricChart,
+  drawTextRight,
+  hypnogramCaptionShort,
+  INK,
+  rangeAverageText,
+} from "./health-chart";
+import {
+  formatDuration,
+  shortDate,
+  stageSeconds,
+  type DailySummary,
+  type MetricSummary,
+} from "./health-derive";
+import {
+  SAMPLE_METRIC_LABELS,
+  SAMPLE_METRIC_SHORT_LABELS,
+  SAMPLE_METRIC_UNITS,
+  type RollupPoint,
+  type SampleMetric,
+} from "./health-types";
+import { stageLabel, type SleepStageName } from "./sleep-stages";
+
+const MARGIN = 10;
+const GUTTER = 14;
+/** Below this the two columns stack instead. */
+const TWO_COLUMN_MIN_WIDTH = 380;
+
+export type GlanceFonts = { small: UiFont; large: UiFont };
+
+/**
+ * One page of the glasses surface.
+ *
+ * ⚠ THE DRILL-DOWN IS A SCROLL CAROUSEL, AND THAT IS AN INTERPRETATION.
+ * Chris, 2026-09-10: "Scrolling to a parameter on the glasses overview should
+ * open that parameter's today/by-hour detail view... whichever line the user
+ * has scrolled to." Read literally, the act of scrolling to a parameter is what
+ * opens it - so scrolling walks a cursor through these pages and the page you
+ * land on IS the detail view, rather than scrolling moving a highlight that a
+ * second click then opens.
+ *
+ * Two things recommend the literal reading beyond its being literal. It costs
+ * one gesture instead of two, which matches the direction of every other note
+ * in that review (less on the glasses, not more). And it needs no back gesture:
+ * the shell already takes double-click for "back out to home"
+ * (`YieldAtRootLayer`), so a drill-down that needed its own back would have had
+ * to invent one out of the ring's three remaining gestures. Scrolling up to
+ * leave a page you scrolled down into needs nothing.
+ *
+ * Click is wired to advance as well, so a user who only ever clicks still gets
+ * round. Recorded as a call, not a spec.
+ */
+export type GlancePage =
+  | { kind: "overview" }
+  | { kind: "metric"; metric: SampleMetric }
+  | { kind: "sleep" };
+
+/**
+ * The cursor's order. Overview first, then the five measured parameters in the
+ * order the overview lists them, then sleep - so scrolling down walks the
+ * summary top to bottom and falls off the end into last night, which is where
+ * the overview's right-hand column already pointed.
+ */
+export const GLANCE_PAGES: readonly GlancePage[] = [
+  { kind: "overview" },
+  { kind: "metric", metric: "heartRate" },
+  { kind: "metric", metric: "spo2" },
+  { kind: "metric", metric: "hrv" },
+  { kind: "metric", metric: "steps" },
+  { kind: "metric", metric: "calories" },
+  { kind: "sleep" },
+];
+
+export type GlanceData = {
+  summary: DailySummary | null;
+  /** Today's by-hour series, per metric. Only the drill-down pages use it. */
+  hourly: Partial<Record<SampleMetric, readonly RollupPoint[]>>;
+  /** Last night as a run of stage blocks, for the sleep detail lanes. */
+  stageBands: readonly { stage: SleepStageName | null; seconds: number }[];
+  /** Wall clock, passed in rather than read, so a preview can pin the date. */
+  nowMs: number;
+  fixture: boolean;
+};
+
+export type GlanceSize = { width: number; height: number };
+
+/** Paint whichever page the cursor is on. */
+export function drawGlancePage(
+  image: GrayImage,
+  size: GlanceSize,
+  fonts: GlanceFonts,
+  page: GlancePage,
+  data: GlanceData,
+): void {
+  switch (page.kind) {
+    case "overview":
+      drawOverview(image, size, fonts, data);
+      return;
+    case "metric":
+      drawMetricDetail(image, size, fonts, page.metric, data);
+      return;
+    case "sleep":
+      drawSleepDetail(image, size, fonts, data);
+      return;
+  }
+}
+
+// ===========================================================================
+// Header and footer, shared by every page
+
+function drawHeader(
+  image: GrayImage,
+  size: GlanceSize,
+  fonts: GlanceFonts,
+  title: string,
+  right: string,
+): number {
+  const { small } = fonts;
+  image.drawText(small, MARGIN, MARGIN, title, INK.title);
+  drawTextRight(image, small, size.width - MARGIN, MARGIN, right, INK.label);
+  const bottom = MARGIN + small.lineHeight + 3;
+  image.drawLine(MARGIN, bottom, size.width - MARGIN, bottom, INK.axis);
+  return bottom;
+}
+
+/**
+ * The scroll hint, and the sample-data badge when the data is generated.
+ *
+ * The hint is not decoration: the drill-down has no on-screen affordance
+ * otherwise - a page that opens on a scroll looks identical to a page that does
+ * nothing until you try it.
+ */
+function drawFooter(
+  image: GrayImage,
+  size: GlanceSize,
+  fonts: GlanceFonts,
+  hint: string,
+  fixture: boolean,
+): void {
+  const { small } = fonts;
+  const y = size.height - small.lineHeight - 2;
+  image.drawText(small, MARGIN, y, hint, INK.faint);
+  if (fixture) drawTextRight(image, small, size.width - MARGIN, y, "Sample data", INK.faint);
+}
+
+// ===========================================================================
+// 1. The overview - a summary, and nothing but
+
+/**
+ * ⚠ CUT DOWN 2026-09-10 on Chris's review. What left this page and why:
+ *
+ *   - The heart-rate trace chart. It was filling the left column's spare
+ *     height and it is the single biggest thing on the page; "I think it just
+ *     needs to be a summary".
+ *   - The hypnogram strip under last night's stats, for the same reason.
+ *   - The min/avg/max triple, replaced by range-and-average
+ *     (`rangeAverageText`), which drops the "min / avg / max" legend line that
+ *     existed only to decode the triple.
+ *
+ * What arrived: an HRV line, revising the first pass's spec.
+ *
+ * The net is that this page is now TEXT ONLY - no charts, no graphics. The
+ * charts did not die, they moved: the trace is the heart-rate drill-down page
+ * one scroll away, and the hypnogram became the sleep detail's four lanes.
+ * That is the actual shape of the revision - the glance got smaller because the
+ * drill-down gave its contents somewhere better to live.
+ */
+function drawOverview(
+  image: GrayImage,
+  size: GlanceSize,
+  fonts: GlanceFonts,
+  data: GlanceData,
+): void {
+  const { small, large } = fonts;
+  const step = lineStep(small);
+  const headerBottom = drawHeader(image, size, fonts, "HEALTH", shortDate(data.nowMs));
+  const summary = data.summary;
+
+  if (!summary) {
+    image.drawText(small, MARGIN, headerBottom + step, "Waiting for ring data...", INK.dim);
+    drawFooter(image, size, fonts, "", data.fixture);
+    return;
+  }
+
+  const twoColumn = size.width >= TWO_COLUMN_MIN_WIDTH;
+  const columnWidth = twoColumn
+    ? Math.floor((size.width - MARGIN * 2 - GUTTER) / 2)
+    : size.width - MARGIN * 2;
+  const rightX = twoColumn ? MARGIN + columnWidth + GUTTER : MARGIN;
+  const top = headerBottom + 6;
+
+  const todayBottom = drawTodayColumn(image, summary, {
+    x: MARGIN,
+    y: top,
+    width: columnWidth,
+    fonts,
+    step,
+  });
+  const nightTop = twoColumn ? top : todayBottom + 8;
+  const nightBottom = drawNightColumn(image, summary, {
+    x: rightX,
+    y: nightTop,
+    width: columnWidth,
+    fonts,
+    step,
+  });
+
+  if (twoColumn) {
+    // The divider stops at the taller column rather than running to the footer.
+    // Now that the page is text-only the columns fill about a third of the
+    // height, and a rule continuing 300px past the last row reads as a drawing
+    // artefact instead of as structure. It also matters more than it looks: on
+    // the glasses an unlit pixel is TRANSPARENT, so every line drawn past the
+    // content is one more thing between the wearer and the world.
+    const divider = MARGIN + columnWidth + Math.floor(GUTTER / 2);
+    image.drawLine(divider, top, divider, Math.max(todayBottom, nightBottom), INK.faint);
+  }
+
+  void large;
+  drawFooter(image, size, fonts, `${GESTURE_SCROLL} detail`, data.fixture);
+}
+
+type ColumnLayout = {
+  x: number;
+  y: number;
+  width: number;
+  fonts: GlanceFonts;
+  step: number;
+};
+
+function drawTodayColumn(image: GrayImage, summary: DailySummary, layout: ColumnLayout): number {
+  const { x, width, fonts, step } = layout;
+  const { small, large } = fonts;
+  let y = layout.y;
+
+  image.drawText(small, x, y, "TODAY", INK.label);
+  y += step;
+
+  // Steps get the large font: it is the number a glance is most often for.
+  const stepsText = summary.steps > 0 ? summary.steps.toLocaleString() : "--";
+  image.drawText(large, x, y, stepsText, INK.title);
+  const stepsWidth = large.measureText(stepsText);
+  image.drawText(
+    small,
+    x + stepsWidth + 6,
+    y + large.lineHeight - small.lineHeight - 1,
+    "steps",
+    INK.label,
+  );
+  y += large.lineHeight + 4;
+
+  const caloriesText = summary.calories > 0 ? `${summary.calories.toLocaleString()} kcal` : "-- kcal";
+  image.drawText(small, x, y, caloriesText, INK.bar);
+  y += step + 4;
+
+  // Range and average, one line each, no legend line underneath.
+  const rows: [string, MetricSummary, string][] = [
+    ["HR", summary.heartRate, SAMPLE_METRIC_UNITS.heartRate],
+    ["SpO2", summary.spo2, SAMPLE_METRIC_UNITS.spo2],
+    ["HRV", summary.hrv, SAMPLE_METRIC_UNITS.hrv],
+  ];
+  for (const [label, metricSummary, unit] of rows) {
+    image.drawText(small, x, y, label, INK.label);
+    drawTextRight(image, small, x + width, y, rangeAverageText(metricSummary, unit), INK.line);
+    y += step;
+  }
+  return y;
+}
+
+function drawNightColumn(image: GrayImage, summary: DailySummary, layout: ColumnLayout): number {
+  const { x, width, fonts, step } = layout;
+  const { small, large } = fonts;
+  let y = layout.y;
+
+  image.drawText(small, x, y, "LAST NIGHT", INK.label);
+  y += step;
+
+  const sleep = summary.sleep;
+  if (!sleep) {
+    image.drawText(small, x, y, "No sleep record", INK.dim);
+    return y + step;
+  }
+
+  image.drawText(large, x, y, formatDuration(sleep.totalSec), INK.title);
+  y += large.lineHeight + 4;
+
+  image.drawText(small, x, y, "Efficiency", INK.label);
+  drawTextRight(image, small, x + width, y, `${Math.round(sleep.efficiencyPercent)}%`, INK.line);
+  y += step + 3;
+
+  // The three stage shares Chris named, as percentages of time asleep. These
+  // come from the record's own named totals, so they are unaffected by the
+  // unconfirmed stage-id mapping the sleep detail's lanes depend on.
+  const rows: [string, number][] = [
+    ["REM", sleep.remPercent],
+    ["Deep", sleep.deepPercent],
+    ["Light", sleep.lightPercent],
+  ];
+  for (const [label, percent] of rows) {
+    image.drawText(small, x, y, label, INK.label);
+    drawTextRight(image, small, x + width, y, `${Math.round(percent)}%`, INK.line);
+    y += step;
+  }
+  return y;
+}
+
+// ===========================================================================
+// 4. The drill-down: one parameter, today, by hour
+
+/**
+ * What the phone's Day view shows for this metric, on the glasses.
+ *
+ * The headline repeats the overview's range-and-average line at full size, so
+ * the page answers the glance's question before the chart is read at all; the
+ * chart then says WHEN. That ordering is the point of the drill-down - "74 avg"
+ * and "and it was 130 at five o'clock" are different facts.
+ */
+function drawMetricDetail(
+  image: GrayImage,
+  size: GlanceSize,
+  fonts: GlanceFonts,
+  metric: SampleMetric,
+  data: GlanceData,
+): void {
+  const { small, large } = fonts;
+  const step = lineStep(small);
+  const headerBottom = drawHeader(
+    image,
+    size,
+    fonts,
+    SAMPLE_METRIC_LABELS[metric].toUpperCase(),
+    "today, by hour",
+  );
+  let y = headerBottom + 6;
+
+  const summary = summaryFor(metric, data.summary);
+  const unit = SAMPLE_METRIC_UNITS[metric];
+
+  if (isCumulativeMetric(metric)) {
+    // Steps and calories are totals, not measurements with a spread, so the
+    // headline is the day's total rather than a range.
+    const total = metric === "steps" ? data.summary?.steps ?? 0 : data.summary?.calories ?? 0;
+    const text = total > 0 ? total.toLocaleString() : "--";
+    image.drawText(large, MARGIN, y, text, INK.title);
+    const width = large.measureText(text);
+    if (unit) {
+      image.drawText(
+        small,
+        MARGIN + width + 6,
+        y + large.lineHeight - small.lineHeight - 1,
+        unit,
+        INK.label,
+      );
+    }
+    y += large.lineHeight + 6;
+  } else {
+    image.drawText(small, MARGIN, y, rangeAverageText(summary, unit), INK.line);
+    y += step + 4;
+  }
+
+  const points = data.hourly[metric] ?? [];
+  const footerHeight = small.lineHeight + 8;
+  const chartHeight = size.height - y - MARGIN - footerHeight;
+  if (chartHeight >= 40) {
+    drawMetricChart(
+      image,
+      { x: MARGIN, y, width: size.width - MARGIN * 2, height: chartHeight },
+      {
+        metric,
+        points,
+        font: small,
+        // Just format the hour - `drawMetricChart` already thins labels to
+        // whatever the column width fits. Thinning here as well multiplies the
+        // two and leaves a single label at midnight.
+        xLabel: (point) => `${new Date(point.startMs).getHours()}`,
+      },
+    );
+  }
+
+  drawFooter(image, size, fonts, `${GESTURE_SCROLL} ${pageHint(metric)}`, data.fixture);
+}
+
+function summaryFor(metric: SampleMetric, summary: DailySummary | null): MetricSummary {
+  const empty: MetricSummary = { min: 0, max: 0, avg: 0, hasData: false };
+  if (!summary) return empty;
+  if (metric === "heartRate") return summary.heartRate;
+  if (metric === "spo2") return summary.spo2;
+  if (metric === "hrv") return summary.hrv;
+  return empty;
+}
+
+function isCumulativeMetric(metric: SampleMetric): boolean {
+  return metric === "steps" || metric === "calories";
+}
+
+/** "SpO2 · HRV" - what scrolling either way from here reaches. */
+function pageHint(metric: SampleMetric): string {
+  const index = GLANCE_PAGES.findIndex(
+    (page) => page.kind === "metric" && page.metric === metric,
+  );
+  const previous = GLANCE_PAGES[index - 1];
+  const next = GLANCE_PAGES[index + 1];
+  return [pageName(previous), pageName(next)].filter(Boolean).join(" · ");
+}
+
+function pageName(page: GlancePage | undefined): string {
+  if (!page) return "";
+  if (page.kind === "overview") return "Summary";
+  if (page.kind === "sleep") return "Sleep";
+  return SAMPLE_METRIC_SHORT_LABELS[page.metric];
+}
+
+// ===========================================================================
+// 4b. The drill-down's special case: one night, four lanes
+
+/**
+ * Sleep's own detail page: the four categories arranged vertically, top to
+ * bottom as Awake, Light, REM, Deep.
+ *
+ * The ordering is Chris's and is deliberately not the week chart's - see
+ * `drawSleepLanes`, which owns the drawing and carries the reasoning and the
+ * flagged proportions call.
+ *
+ * The unconfirmed-mapping caption rides along because this page IS the
+ * hypnogram: lanes are the only thing on either surface that depends on the raw
+ * stage ids, so it is the only place that has to hedge. The overview's
+ * percentages come from named totals and say so by not carrying this caption.
+ */
+function drawSleepDetail(
+  image: GrayImage,
+  size: GlanceSize,
+  fonts: GlanceFonts,
+  data: GlanceData,
+): void {
+  const { small, large } = fonts;
+  const step = lineStep(small);
+  const sleep = data.summary?.sleep ?? null;
+  const headerBottom = drawHeader(image, size, fonts, "SLEEP", "last night");
+  let y = headerBottom + 6;
+
+  if (!sleep) {
+    image.drawText(small, MARGIN, y, "No sleep record", INK.dim);
+    drawFooter(image, size, fonts, `${GESTURE_SCROLL} Calories · Summary`, data.fixture);
+    return;
+  }
+
+  // Total and efficiency on one line, so the lanes get the height.
+  const totalText = formatDuration(sleep.totalSec);
+  image.drawText(large, MARGIN, y, totalText, INK.title);
+  drawTextRight(
+    image,
+    small,
+    size.width - MARGIN,
+    y + large.lineHeight - small.lineHeight - 1,
+    `${Math.round(sleep.efficiencyPercent)}% efficiency`,
+    INK.label,
+  );
+  y += large.lineHeight + 6;
+
+  const footerHeight = small.lineHeight + 8;
+  const captionHeight = step;
+  const laneHeight = size.height - y - MARGIN - footerHeight - captionHeight;
+  if (laneHeight >= 40) {
+    drawSleepLanes(
+      image,
+      { x: MARGIN, y, width: size.width - MARGIN * 2, height: laneHeight },
+      {
+        bands: data.stageBands,
+        font: small,
+        laneText: (stage) => ({
+          label: stageLabel(stage),
+          value: formatDuration(stageSeconds(stage, sleep)),
+        }),
+      },
+    );
+    y += laneHeight;
+  }
+
+  image.drawText(small, MARGIN, y, hypnogramCaptionShort(), INK.faint);
+  drawFooter(image, size, fonts, `${GESTURE_SCROLL} Calories · Summary`, data.fixture);
+}

--- a/app/health/health-ingest.ts
+++ b/app/health/health-ingest.ts
@@ -1,0 +1,311 @@
+/**
+ * Wire records -> stored samples. The one place that knows what the ring's
+ * decoded records mean in wall-clock terms.
+ *
+ * ## This is written but NOT wired up, on purpose
+ *
+ * The live BLE path lives on the `ring-health-protocol` branch, which this one
+ * deliberately does not touch. What is here is the whole conversion - the part
+ * with the judgement calls in it - written against a structural description of
+ * `RingProtocol.java`'s record types rather than an import of them, so that
+ * branch and this one can be joined later without either having been built
+ * around the other.
+ *
+ * ## WHERE THE LIVE WIRING GOES - the follow-up, in full
+ *
+ * ⚠ HISTORICAL. This section is the plan, and it has since been built:
+ * `health-live.ts` is the caller. One detail of it is now WRONG - the live path
+ * must NOT use `getRingHealthRecords()`, which is a pure copy and left the
+ * Java-side buffer growing forever. It uses `takeRingHealthBatch()` and hands
+ * the records back with `clearRingHealthRecordsBelow()` once the store write
+ * has succeeded. Kept below for the reasoning, not as instructions.
+ *
+ * `FaceclawBleCommunicator` already accumulates decoded records into a capped
+ * in-memory list with a `getRingHealthRecords()` getter (implement-return,
+ * section 2). The bridge already exposes the native object to TypeScript:
+ * `FaceclawCommunicatorBridge.getNativeCommunicator()`. So the follow-up is:
+ *
+ *   1. In `dashboard-controller.ts`, after `connect()` succeeds, poll
+ *      `communicator.getNativeCommunicator().getRingHealthRecords()` on the
+ *      same 30-minute cadence the Java side already throttles health pulls to.
+ *   2. Map each Java record onto the `Wire*` shapes below - a field-for-field
+ *      copy; the names were chosen to match.
+ *   3. Hand the result to `convertRecords()` and pass its `samples`/`sleep`
+ *      straight to `healthStore().ingestSamples()` / `.ingestSleep()`.
+ *
+ * Doing it as a poll rather than a callback is what keeps it a small change:
+ * adding a method to `FaceclawBleCommunicatorListener` forces an edit on every
+ * implementer, which is exactly the reasoning that put the records in a getter
+ * in the first place.
+ *
+ * A note for whoever does it: ingest is idempotent (`HealthStore` dedupes on
+ * metric + bucket start), so re-reading the same capped list every poll is
+ * correct and costs one no-op per record. Do NOT drain the list on read - it
+ * is the only copy until this store has written it.
+ *
+ * No NativeScript imports here, so it runs under plain node in `tests/`.
+ */
+
+import {
+  HOUR_MS,
+  TEN_MINUTES_MS,
+  type HealthSample,
+  type SleepSession,
+  type SleepSegment,
+  startOfLocalDay,
+} from "./health-types";
+
+/** `RingProtocol.HourlyRecord`, for heart rate (`01:01`), SpO2 (`02:01`), HRV (`04:01`). */
+export type WireHourlyRecord = {
+  kind: "hourly";
+  metric: "heartRate" | "spo2" | "hrv";
+  /**
+   * Absolute local ms the page's group index 0 refers to, from the record's
+   * own six-byte ANCHOR field, or null on a backlog page that carried six
+   * zero bytes instead.
+   */
+  anchorMs: number | null;
+  groups: readonly { hourIndex: number; avg: number; max: number; min: number }[];
+};
+
+/** `RingProtocol.StepsRecord` (`05:01`). */
+export type WireStepsRecord = {
+  kind: "steps";
+  /** The day anchor. Steps pages always carried one in the capture. */
+  anchorMs: number | null;
+  /** Raw buckets. `index` is the ring's own, whose meaning is NOT known. */
+  buckets: readonly { index: number; steps: number; activeCalories: number; totalCalories: number }[];
+};
+
+/** `RingProtocol.SleepRecord` (`06:01`). */
+export type WireSleepRecord = {
+  kind: "sleep";
+  /**
+   * The ring's own `start_ts`/`end_ts`, in seconds.
+   *
+   * These were documented here as "ring-relative seconds - NOT Unix time",
+   * because nothing in the offline capture proved otherwise. The first real
+   * record off the hardware (2026-09-12) falsified that: `start_ts` decodes to
+   * a plain Unix timestamp kept on the RING'S clock, which runs ahead of real
+   * time. `clockCorrectionMs` is how a caller says by how much.
+   *
+   * Left as raw seconds here rather than corrected upstream so a caller with
+   * no correction to offer (an offline capture, a fixture) still gets the old,
+   * honestly-unresolved behaviour instead of a confidently wrong date.
+   */
+  startTs: number;
+  endTs: number;
+  totalSec: number;
+  wakeSec: number;
+  remSec: number;
+  lightSec: number;
+  deepSec: number;
+  segments: readonly SleepSegment[];
+  /** Wall-clock ms the record was received; the only real time in it. */
+  receivedAtMs: number;
+  /**
+   * How far AHEAD of real wall-clock time `startTs`/`endTs` run, in ms, or
+   * omitted when the caller cannot say. Supplying it is what promotes the
+   * session from `timeResolved: false` to a real placement - see
+   * `convertSleep`. The value itself is the producer's problem, not this
+   * module's: see `sleepClockCorrectionMs` in `health-live.ts`.
+   */
+  clockCorrectionMs?: number;
+};
+
+export type WireRecord = WireHourlyRecord | WireStepsRecord | WireSleepRecord;
+
+export type ConversionResult = {
+  samples: HealthSample[];
+  sleep: SleepSession[];
+  /** Every record or group deliberately not stored, with the reason. */
+  skipped: { what: string; why: string }[];
+};
+
+export function convertRecords(records: readonly WireRecord[]): ConversionResult {
+  const result: ConversionResult = { samples: [], sleep: [], skipped: [] };
+  for (const record of records) {
+    if (record.kind === "hourly") convertHourly(record, result);
+    else if (record.kind === "steps") convertSteps(record, result);
+    else convertSleep(record, result);
+  }
+  return result;
+}
+
+/**
+ * Hourly pages. An ANCHORED page dates itself exactly: group `i` is
+ * `anchor + i hours`, which the decode verified against every group that had a
+ * row to check against.
+ *
+ * An UNANCHORED (backlog) page is dropped rather than placed. The decode did
+ * solve where one such page landed, but explicitly could not derive the rule
+ * that produced it and warned that a future page anchored elsewhere would
+ * break it. `RingProtocol.java` already made the matching call - it hands
+ * backlog groups out with `UNKNOWN_TIME` rather than an invented time - and a
+ * health chart is exactly the wrong place to be the first component that
+ * guesses. Dropping loses a page; guessing corrupts the history silently.
+ */
+function convertHourly(record: WireHourlyRecord, result: ConversionResult): void {
+  if (record.anchorMs === null) {
+    result.skipped.push({
+      what: `${record.metric} page, ${record.groups.length} groups`,
+      why: "backlog page with no anchor - no verified rule for dating it",
+    });
+    return;
+  }
+  for (const group of record.groups) {
+    const startMs = record.anchorMs + group.hourIndex * HOUR_MS;
+    result.samples.push({
+      metric: record.metric,
+      startMs,
+      spanMs: HOUR_MS,
+      min: group.min,
+      max: group.max,
+      avg: group.avg,
+      total: group.avg,
+    });
+  }
+}
+
+/**
+ * Steps and calories, at TEN-MINUTE resolution.
+ *
+ * ## The index is cracked (2026-09-12)
+ *
+ * This used to emit one day-span sample holding the day's total, because the
+ * bucket index was only trusted as an identity, not as a time. It now resolves:
+ * **bucket `i` starts at `anchor + i * 10 minutes`**, with the anchor read
+ * offset-corrected like every other record type.
+ *
+ * Confirmed twice. The decisive check: a live ledger held 25 contiguous buckets
+ * (1-25) under a corrected anchor of 20:00, while the file's mtime was 00:18
+ * local - and `20:00 + 25 * 10min` is 00:10-00:20, which is the window that was
+ * actually being filled. The older "index runs 0-34 then jumps to 130-132"
+ * observation came from an offline capture spanning more than one ring-day;
+ * indices are per-record and contiguous within one.
+ *
+ * ## What this changes downstream
+ *
+ * The day total is no longer readable off any field of a day's rollup - it is
+ * `sum`, and only `sum`, because `count` is now ~144 rather than 1. Checked on
+ * 2026-09-12: every steps/calories reader already uses the summing path
+ * (`dailySummary` -> `sumOf` -> `sample.total`; `rollupSeries` -> `rollupOf` ->
+ * `sum`; the phone view model's steps branch reads `point.sum`), so nothing had
+ * to change for this. Do not add a reader that takes `max` or `avg` for a step
+ * total.
+ *
+ * A ring-day starts at 20:00 local (the ring's clock runs 4h fast, so its
+ * midnight is our 20:00), which means one record's buckets straddle two
+ * calendar days. That is correct and is the reason the day figure moves when
+ * this lands: the evening buckets stop being filed under tomorrow.
+ */
+function convertSteps(record: WireStepsRecord, result: ConversionResult): void {
+  if (record.anchorMs === null) {
+    result.skipped.push({
+      what: `steps page, ${record.buckets.length} buckets`,
+      why: "no anchor - cannot date the buckets",
+    });
+    return;
+  }
+  const anchorMs = record.anchorMs;
+  for (const bucket of record.buckets) {
+    const startMs = anchorMs + bucket.index * TEN_MINUTES_MS;
+    result.samples.push({
+      metric: "steps",
+      startMs,
+      spanMs: TEN_MINUTES_MS,
+      min: bucket.steps,
+      max: bucket.steps,
+      avg: bucket.steps,
+      total: bucket.steps,
+    });
+    result.samples.push({
+      metric: "calories",
+      startMs,
+      spanMs: TEN_MINUTES_MS,
+      min: bucket.totalCalories,
+      max: bucket.totalCalories,
+      avg: bucket.totalCalories,
+      total: bucket.totalCalories,
+    });
+  }
+}
+
+/**
+ * Sleep sessions.
+ *
+ * The durations are exact and need no anchoring - they come from named byte
+ * offsets and the decode reproduced a whole exported row from them. The
+ * SESSION TIME is the problem: `start_ts`/`end_ts` are ring-relative seconds,
+ * nothing in the record carries an absolute date, and the two unidentified
+ * fields that might have carried one were not cracked. Even's own app gets
+ * this wrong - one exported row is stamped 1979.
+ *
+ * RESOLVED, 2026-09-12, by the first real record off the hardware rather than
+ * by cracking `pay[3:9]`: `start_ts` is already a Unix timestamp, just kept on
+ * the ring's own clock. A caller that knows how far that clock runs ahead
+ * passes `clockCorrectionMs` and gets a genuinely placed session.
+ *
+ * ⚠ THE OLD FLAGGED GUESS SURVIVES for callers that do NOT pass it (offline
+ * captures, fixtures): the session is attributed to the local day it was
+ * RECEIVED on and `timeResolved` is false to say so. That guess is made rather
+ * than avoided because "last night's sleep" is half of what the glasses glance
+ * is for, and a record with no day at all cannot appear there. It is right
+ * whenever the ring is synced the same day it is worn and wrong for a backlog
+ * session pulled days later - which is why the UI never prints a date for an
+ * unresolved session, only "last night", and shows the unresolved marker.
+ */
+function convertSleep(record: WireSleepRecord, result: ConversionResult): void {
+  const durationSec = Math.max(0, record.endTs - record.startTs);
+  const common = {
+    totalSec: record.totalSec,
+    wakeSec: record.wakeSec,
+    remSec: record.remSec,
+    lightSec: record.lightSec,
+    deepSec: record.deepSec,
+    segments: record.segments,
+  };
+
+  if (typeof record.clockCorrectionMs === "number") {
+    const startMs = record.startTs * 1000 - record.clockCorrectionMs;
+    const endMs = (record.startTs + durationSec) * 1000 - record.clockCorrectionMs;
+    result.sleep.push({
+      // The WAKE-UP day, which is what `dailySummary` looks a night up by, and
+      // what the old receivedAtMs guess was approximating. Taken from the end
+      // of the session so a night that starts before midnight still belongs to
+      // the morning it ends on.
+      dayStartMs: startOfLocalDay(endMs),
+      startMs,
+      endMs,
+      ...common,
+      timeResolved: true,
+    });
+    return;
+  }
+
+  result.sleep.push({
+    dayStartMs: startOfLocalDay(record.receivedAtMs),
+    // Raw seconds are kept as-is so the pair still describes the night's
+    // length and ordering; `timeResolved` is what says not to read them as
+    // wall-clock time.
+    startMs: record.startTs * 1000,
+    endMs: (record.startTs + durationSec) * 1000,
+    ...common,
+    timeResolved: false,
+  });
+}
+
+/**
+ * The consistency check the decode found holds on every real record: the
+ * segment run must account for exactly the time in bed. Worth running on
+ * ingest - a record that fails it is a decode fault, not a strange night.
+ */
+export function sleepIdentityHolds(record: {
+  totalSec: number;
+  wakeSec: number;
+  segments: readonly SleepSegment[];
+}): boolean {
+  let half = 0;
+  for (const segment of record.segments) half += segment.halfMinutes;
+  return half * 30 === record.totalSec + record.wakeSec;
+}

--- a/app/health/health-live.ts
+++ b/app/health/health-live.ts
@@ -1,0 +1,582 @@
+/**
+ * Live ring → store. The producer side of `health-ingest.ts`.
+ *
+ * `health-ingest.ts` was built with a complete wire→domain conversion and no
+ * caller; this is the caller. It reads whatever `FaceclawBleCommunicator` has
+ * decoded off the ring this session, marshals the Java records into the
+ * `WireRecord` shapes that module already expects, and writes the result
+ * through the store's own deduping ingest.
+ *
+ * Three things worth knowing:
+ *
+ * 1. **It pulls, it does not subscribe, and it CONSUMES.** There is no push
+ *    event for health records, so both surfaces call this when they open and on
+ *    their existing refresh tick. `takeRingHealthBatch()` hands over what the
+ *    communicator is holding together with a watermark, and once the store
+ *    write has succeeded `clearRingHealthRecordsBelow()` hands that much back
+ *    as consumed. Cut and paste, not copy paste.
+ *
+ *    It used to be a pure copy, and nothing ever cleared the Java-side list, so
+ *    every 60s tick re-processed the whole session's history. Measured
+ *    2026-09-12: `samples-2026-09.jsonl` grew 22,505 -> 28,552 lines in eight
+ *    hours, the buffer climbing 12 -> 24 records and samples-written-per-cycle
+ *    8 -> 14. The store's dedupe kept the DATA right the whole time; it was the
+ *    work and the file that grew without bound.
+ *
+ * 2. **Fixtures are purged, not just unlabelled, before the first real write.**
+ *    `clearFixtureMarker()` only drops the badge; the 45 days of generated
+ *    samples would stay in the store and become indistinguishable from real
+ *    data the moment the badge went away. That is precisely the artefact
+ *    `health-seed.ts`' own header warns about, so the first genuine record
+ *    wipes the store files outright.
+ *
+ * 3. **Records the decode could not date are dropped, not placed.**
+ *    `RingProtocol` hands out `UNKNOWN_TIME` (-1) for an unanchored backlog
+ *    page rather than inventing a time; that maps to `anchorMs: null` here and
+ *    `convertRecords` skips it with a reason. Do not "fix" this by substituting
+ *    now() — a health chart is the wrong place to guess a timestamp.
+ */
+
+import {
+  convertRecords,
+  type WireHourlyRecord,
+  type WireRecord,
+  type WireSleepRecord,
+  type WireStepsRecord,
+} from "./health-ingest";
+import { markLiveData, purgeFixtureData } from "./health-seed";
+import { healthStore } from "./health-store-files";
+import { startOfLocalDay, type SleepSegment } from "./health-types";
+import { File, knownFolders } from "@nativescript/core";
+
+/** `RingProtocol.UNKNOWN_TIME` — the decoder's "I will not guess" sentinel. */
+const UNKNOWN_TIME = -1;
+
+/** `RingProtocol.CMD_HI_*`. */
+const CMD_HEART_RATE = 0x01;
+const CMD_SPO2 = 0x02;
+const CMD_HRV = 0x04;
+const CMD_STEPS = 0x05;
+const CMD_SLEEP = 0x06;
+
+/** `SleepRecord.recordState`: 2 is the empty end-of-list marker, not a night. */
+const SLEEP_STATE_EMPTY = 2;
+
+const HOURLY_METRIC: { [cmdHi: number]: WireHourlyRecord["metric"] } = {
+  [CMD_HEART_RATE]: "heartRate",
+  [CMD_SPO2]: "spo2",
+  [CMD_HRV]: "hrv",
+};
+
+function activeCommunicator(): any {
+  try {
+    return (com as any).faceclaw.app.FaceclawBleCommunicator.getActive() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The ring timestamps in a frame 4 hours ahead of real time, and that is our
+ * own doing: the handshake sets its clock to `now + 14400s`, because that is
+ * what a real Even write carries (verified against six of them). Even's app
+ * evidently subtracts the same offset on the way back out. We were not, so
+ * every hourly sample landed 4 hours in the future.
+ *
+ * MEASURED, not theorised. Stored samples read 09:00/10:00/11:00 local while
+ * the actual time was 07:15; minus four hours gives 05:00/06:00/07:00, which
+ * is exactly right for a ring that had just reported the current hour.
+ *
+ * ⚠ This value is PAIRED with the offset in `sendRingHandshake()`. They must
+ * move together.
+ *
+ * Both were hardcoded to 14400. As of 2026-09-12 both COMPUTE it: 14400 was
+ * only ever right because every capture behind this work was taken in EDT,
+ * where 14400s is the magnitude of the UTC offset. Computing it is identical
+ * today and survives DST.
+ *
+ * ⚠ MIND THE SIGN. The quantity is "how far AHEAD of real time the ring's clock
+ * runs", which is the magnitude of a west-of-UTC offset — positive 14400 in
+ * EDT. `getTimezoneOffset()` is already minutes WEST of UTC (+240 in EDT), so
+ * it is used as-is, NOT negated. Java's `TimeZone.getOffset()` uses the
+ * opposite convention and is negated there; the two agree on +14400.
+ *
+ * Worth recording because the first cut of this change got the sign backwards
+ * on both sides at once — consistently, so they stayed "paired", and still
+ * wrong by 8 hours. Only the handshake's own assertion log caught it.
+ *
+ * Note this direction is the OPPOSITE of the "ring stores naive local time"
+ * hypothesis (which predicts `epoch + utc_offset`, i.e. 4h behind). Measured
+ * behaviour is 4h ahead. The hypothesis is unconfirmed; the measurement rules.
+ */
+function ringClockOffsetMs(atMs: number): number {
+  return new Date(atMs).getTimezoneOffset() * 60 * 1000;
+}
+
+/**
+ * Sleep timestamps need TWICE the correction the hourly samples need.
+ *
+ * ⚠ EMPIRICAL, AND THE MECHANISM IS UNEXPLAINED. Do not read a story into the
+ * factor of 2. The last time this file invented a tidy explanation for a ring
+ * clock quirk ("the ring stores naive local time") it was falsified the next
+ * day, which is why the hourly comment above ends with "the measurement rules".
+ * The same applies here, more so: nothing about a sleep record is known to
+ * differ from an hourly one in how it is stamped, and yet the correction does.
+ *
+ * The evidence, 2026-09-12, the first real sleep record off the hardware:
+ * `start_ts` decodes raw to 10:21:01 EDT. Chris confirmed the true window two
+ * independent ways - he slept "straight through from around 1:30 AM to 9:30 AM",
+ * and separately reported seeing only the first block with "another 4 or so
+ * hours after that". Under -4h the block is 06:21 -> 09:25, which puts the
+ * missing time BEFORE it and contradicts what the device showed. Under -8h it
+ * is 02:21 -> 05:25, leaving 05:25 -> 09:30 (4h05m) missing AFTER it, which is
+ * what he saw.
+ *
+ * Expressed as twice `ringClockOffsetMs` rather than a fresh 28800 so the
+ * November DST change moves the hourly correction and this one together. Like
+ * the hourly path it is evaluated at the RAW instant, so within ~8h of a DST
+ * switch it can pick the wrong side by an hour - the same caveat, deliberately
+ * kept identical rather than special-cased here.
+ */
+function sleepClockOffsetMs(atMs: number): number {
+  return 2 * ringClockOffsetMs(atMs);
+}
+
+function anchorToMs(anchorUnixSeconds: number, applyClockOffset: boolean): number | null {
+  if (anchorUnixSeconds === UNKNOWN_TIME) return null;
+  const ms = anchorUnixSeconds * 1000;
+  return applyClockOffset ? ms - ringClockOffsetMs(ms) : ms;
+}
+
+/**
+ * Per-day step-bucket ledger.
+ *
+ * **Why this has to exist.** The ring does not resend the whole day: a pull
+ * delivers only the buckets new since the last successful one, the same
+ * watermark model every other record type uses. Measured 2026-09-11:
+ * 25 buckets / 222 steps, then 3 / 0, then 2 / 0, then 2 / 70. A cumulative
+ * day total cannot go 222 → 0 → 70.
+ *
+ * `convertSteps()` sums the buckets it is handed and emits that as the day's
+ * total, which was right for the offline captures it was written against —
+ * there, one sync carried everything. Live, it means each pull overwrites the
+ * day with just that pull's increment, so the step count reads as "since the
+ * last pull" and lurches downward. So this keeps the day's buckets and hands
+ * `convertSteps()` the accumulated set, leaving that function pure.
+ *
+ * **Merge is max-by-index, not addition and not last-write-wins.** A bucket is
+ * a time window's own total, so a window redelivered later carries a larger
+ * value, not an increment to add — addition would double-count every open
+ * window. Taking the max rather than the last value makes the merge
+ * ORDER-INDEPENDENT, which matters because a single sync pass merges several
+ * records that overlap: measured 2026-09-12, four steps records in one pass
+ * agreed on every bucket's step count but disagreed on its calorie fields, so
+ * last-write-wins made the day's calorie total ping-pong 643 ↔ 671 forever,
+ * appending two lines to the sample shard every cycle. Max is consistent with
+ * the documented model (a window's total only grows as it fills) and settles.
+ *
+ * **The ledger holds MANY days, not one.** It used to hold exactly one, and
+ * kept it only while the incoming day matched — so the moment a record from
+ * another ring-day arrived, the whole accumulated day was discarded and
+ * rebuilt from that one pull. With `syncLiveRecords()` re-processing the
+ * communicator's entire record history every 60s, that produced a repeating
+ * cycle of partial sums, each written to the store as a genuine day total
+ * (measured: a 12-state cycle, repeated 132 times, 22k lines in a day).
+ * Holding every day makes the replay idempotent instead of destructive — and
+ * no theory about WHY records replay is needed for that to hold.
+ *
+ * The day key is `startOfLocalDay(corrected anchor)`, which is the ring's own
+ * day start, not calendar midnight — the ring's day begins at 20:00 local
+ * because its clock runs 4h fast. That is fine: the key is an identity, and
+ * the per-bucket timestamps carry the real wall-clock placement.
+ */
+type StepDayBuckets = { [index: string]: { steps: number; active: number; total: number } };
+
+type StepBucketLedger = {
+  /** `dayStartMs` (as a string key) -> that day's buckets. */
+  days: { [dayStartMs: string]: StepDayBuckets };
+};
+
+/** The pre-2026-09-12 single-day shape, migrated on read rather than dropped. */
+type LegacyStepBucketLedger = { dayStartMs: number; buckets: StepDayBuckets };
+
+/** How many ring-days to keep. Enough for a weekly chart, bounded on disk. */
+const LEDGER_DAYS_KEPT = 7;
+
+function ledgerPath(): string {
+  return `${knownFolders.documents().getFolder("health").path}/steps-ledger.json`;
+}
+
+function readLedger(): StepBucketLedger | null {
+  try {
+    if (!File.exists(ledgerPath())) return null;
+    const parsed = JSON.parse(File.fromPath(ledgerPath()).readTextSync()) as
+      | StepBucketLedger
+      | LegacyStepBucketLedger;
+    if (parsed && (parsed as StepBucketLedger).days) return parsed as StepBucketLedger;
+    // Migrate the single-day shape rather than discarding it: the file on the
+    // phone holds real step data the ring may not re-deliver.
+    //
+    // ⚠ RE-KEY IT. The legacy `dayStartMs` was `startOfLocalDay(RAW anchor)`,
+    // computed before the anchor was offset-corrected, so carrying it across
+    // verbatim files the day 4h too late — under a key the corrected code will
+    // never write to again. The accumulated buckets would sit there stranded
+    // while the same ring-day restarted empty beside them. Measured doing
+    // exactly that on 2026-09-12: a ledger with "2 days" that were one day.
+    const legacy = parsed as LegacyStepBucketLedger;
+    if (typeof legacy?.dayStartMs === "number" && legacy.buckets) {
+      const corrected = legacy.dayStartMs - ringClockOffsetMs(legacy.dayStartMs);
+      return { days: { [String(startOfLocalDay(corrected))]: legacy.buckets } };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Keep the ledger bounded. Newest `LEDGER_DAYS_KEPT` days survive. */
+function pruneLedger(ledger: StepBucketLedger): void {
+  const keys = Object.keys(ledger.days).sort((a, b) => Number(b) - Number(a));
+  for (const key of keys.slice(LEDGER_DAYS_KEPT)) delete ledger.days[key];
+}
+
+function writeLedger(ledger: StepBucketLedger): void {
+  try {
+    File.fromPath(ledgerPath()).writeTextSync(JSON.stringify(ledger));
+  } catch (error) {
+    console.warn("health live: steps ledger write failed", error);
+  }
+}
+
+/** Merge this pull's buckets into that ring-day's ledger and return its full set. */
+function accumulateStepBuckets(
+  dayStartMs: number,
+  delivered: readonly { index: number; steps: number; activeCalories: number; totalCalories: number }[],
+): { index: number; steps: number; activeCalories: number; totalCalories: number }[] {
+  const ledger: StepBucketLedger = readLedger() ?? { days: {} };
+  const dayKey = String(dayStartMs);
+  const day: StepDayBuckets = ledger.days[dayKey] ?? {};
+  ledger.days[dayKey] = day;
+  for (const bucket of delivered) {
+    const existing = day[String(bucket.index)];
+    // Max, not overwrite — see the type's header. Keeps the merge order-independent.
+    day[String(bucket.index)] = {
+      steps: Math.max(existing?.steps ?? 0, bucket.steps),
+      active: Math.max(existing?.active ?? 0, bucket.activeCalories),
+      total: Math.max(existing?.total ?? 0, bucket.totalCalories),
+    };
+  }
+  pruneLedger(ledger);
+  writeLedger(ledger);
+  const merged = Object.keys(day).map((key) => ({
+    index: Number(key),
+    steps: day[key]!.steps,
+    activeCalories: day[key]!.active,
+    totalCalories: day[key]!.total,
+  }));
+  const steps = merged.reduce((acc, b) => acc + b.steps, 0);
+  const calories = merged.reduce((acc, b) => acc + b.totalCalories, 0);
+  console.log(
+    `health live: steps ledger +${delivered.length} delivered -> ${merged.length} buckets held ` +
+      `for ring-day ${new Date(dayStartMs).toISOString()}, ${steps} steps / ${calories} cal, ` +
+      `${Object.keys(ledger.days).length} days in ledger`,
+  );
+  return merged;
+}
+
+function toWire(record: any): WireRecord | null {
+  const cmdHi = Number(record.cmdHi);
+
+  const metric = HOURLY_METRIC[cmdHi];
+  if (metric) {
+    const groups: { hourIndex: number; avg: number; max: number; min: number }[] = [];
+    const raw = record.groups;
+    for (let i = 0; i < raw.length; i++) {
+      const group = raw[i];
+      groups.push({
+        hourIndex: Number(group.hourIndex),
+        avg: Number(group.avg),
+        max: Number(group.max),
+        min: Number(group.min),
+      });
+    }
+    return { kind: "hourly", metric, anchorMs: anchorToMs(Number(record.anchorUnixSeconds), true), groups };
+  }
+
+  if (cmdHi === CMD_STEPS) {
+    const buckets: { index: number; steps: number; activeCalories: number; totalCalories: number }[] = [];
+    const raw = record.buckets;
+    for (let i = 0; i < raw.length; i++) {
+      const bucket = raw[i];
+      buckets.push({
+        index: Number(bucket.index),
+        steps: Number(bucket.steps),
+        // UNVERIFIED MAPPING. The decode never resolved which of the record's
+        // two calorie-like fields is active vs total burn, which is why the
+        // Java side names them calorieLike2/calorieLike3 rather than committing.
+        // convertSteps() sums totalCalories, so if the daily calorie figure
+        // reads wrong against Even's own export, swap these two — that is the
+        // whole fix, and it is the only thing here resting on a guess.
+        activeCalories: Number(bucket.calorieLike2),
+        totalCalories: Number(bucket.calorieLike3),
+      });
+    }
+    // Offset-corrected like every other record type, as of 2026-09-12.
+    //
+    // This used to pass `false`, and the reasoning was that flooring the raw
+    // anchor to the local day "absorbed" the 4h shift and landed on the right
+    // date, where subtracting would push the day boundary back to 20:00 the
+    // previous evening. That was solving the wrong problem. The anchor was
+    // being asked to carry the DATE LABEL for a single day-blob sample, so it
+    // had to be bent until the label came out right.
+    //
+    // With the bucket index cracked (bucket i starts at anchor + i*10min), the
+    // anchor no longer carries a date at all — it is the true start instant of
+    // bucket 0, and each bucket now dates itself. So the anchor must simply be
+    // correct, and correct means offset-corrected: measured 2026-09-12 00:36,
+    // the raw anchor read 00:00 today while the record's own 25 buckets place
+    // the series start at 20:00 the previous evening, which is exactly the 4h.
+    //
+    // The ring's day really does begin at 20:00 local, because its clock runs
+    // 4h fast and its day starts at ITS midnight. A ring-day therefore straddles
+    // two calendar days, and the buckets land on whichever real day they fall
+    // in — which is the point.
+    const anchorMs = anchorToMs(Number(record.anchorUnixSeconds), true);
+    if (anchorMs === null) return { kind: "steps", anchorMs: null, buckets };
+    // Hand convertSteps() the whole day, not just this pull's increment.
+    const accumulated = accumulateStepBuckets(startOfLocalDay(anchorMs), buckets);
+    return { kind: "steps", anchorMs, buckets: accumulated };
+  }
+
+  if (cmdHi === CMD_SLEEP) {
+    if (Number(record.recordState) === SLEEP_STATE_EMPTY) return null;
+    const segments: SleepSegment[] = [];
+    const raw = record.segments;
+    for (let i = 0; i < raw.length; i++) {
+      const segment = raw[i];
+      // Java calls it `stage`, the domain type calls it `stageId` - both are
+      // the same raw 0-3 ring id, deliberately unresolved here (see sleep-stages.ts).
+      segments.push({ stageId: Number(segment.stage), halfMinutes: Number(segment.halfMinutes) });
+    }
+    const startTs = Number(record.startTs);
+    const endTs = Number(record.endTs);
+    const correction = sleepClockOffsetMs(startTs * 1000);
+    // The assertion log for the -8h correction. One sleep record a night makes
+    // this cheap, and a wrong clock frame is otherwise invisible until someone
+    // reads a chart and disbelieves it.
+    console.log(
+      `health live: sleep raw ${new Date(startTs * 1000).toString()} -> corrected ` +
+        `${new Date(startTs * 1000 - correction).toString()} .. ` +
+        `${new Date(endTs * 1000 - correction).toString()} (-${correction / 3600000}h)`,
+    );
+    return {
+      kind: "sleep",
+      startTs,
+      endTs,
+      clockCorrectionMs: correction,
+      totalSec: Number(record.totalTime),
+      wakeSec: Number(record.wakeTime),
+      remSec: Number(record.remTime),
+      lightSec: Number(record.lightTime),
+      deepSec: Number(record.deepTime),
+      segments,
+      receivedAtMs: Number(record.receivedAtMs),
+    };
+  }
+
+  return null;
+}
+
+export type LiveSyncResult = {
+  /** Records the communicator was holding. 0 means no pull has landed yet. */
+  seen: number;
+  /** Samples genuinely new to the store. */
+  samplesWritten: number;
+  /** Sleep sessions genuinely new to the store. */
+  sleepWritten: number;
+  /** Conversions deliberately declined, with reasons, from `convertRecords`. */
+  skipped: { what: string; why: string }[];
+};
+
+const EMPTY: LiveSyncResult = { seen: 0, samplesWritten: 0, sleepWritten: 0, skipped: [] };
+
+/**
+ * Read the communicator's decoded records into the durable store.
+ *
+ * Safe to call on every open and every refresh: the store dedupes, and an
+ * absent communicator (no glasses process, preview build) is a no-op rather
+ * than an error.
+ */
+/**
+ * Tell the communicator the snapshot is durably stored and may be dropped.
+ *
+ * Deliberately swallows its own failure: a clear that does not happen costs a
+ * little growth, and there is nothing useful to do about it here. The bias runs
+ * one way throughout - under-clearing is cheap, over-clearing loses data.
+ */
+function consumeUpTo(communicator: any, watermark: number): void {
+  try {
+    const dropped = Number(communicator.clearRingHealthRecordsBelow(watermark));
+    if (dropped > 0) {
+      console.log(`health live: consumed ${dropped} records (watermark ${watermark})`);
+    }
+  } catch (error) {
+    console.warn("health live: could not clear consumed records", error);
+  }
+}
+
+export function syncLiveRecords(): LiveSyncResult {
+  const communicator = activeCommunicator();
+  if (!communicator) return EMPTY;
+
+  let batch: any;
+  try {
+    batch = communicator.takeRingHealthBatch();
+  } catch (error) {
+    console.warn("health live: could not read ring records", error);
+    return EMPTY;
+  }
+  if (!batch) return EMPTY;
+  const records = batch.getRecords();
+  // Identifies exactly this snapshot. Anything the ring pushes from here on is
+  // numbered above it and therefore cannot be cleared by this pass - which is
+  // what keeps a page landing mid-ingest from being dropped.
+  const watermark = Number(batch.getWatermark());
+  if (!records || !records.size || records.size() === 0) return EMPTY;
+
+  const wire: WireRecord[] = [];
+  const size = records.size();
+  for (let i = 0; i < size; i++) {
+    try {
+      const converted = toWire(records.get(i));
+      if (converted) wire.push(converted);
+    } catch (error) {
+      console.warn("health live: skipped an undecodable record", error);
+    }
+  }
+  if (wire.length === 0) return { ...EMPTY, seen: size };
+
+  const { samples, sleep, skipped } = convertRecords(wire);
+  if (samples.length === 0 && sleep.length === 0) {
+    return { seen: size, samplesWritten: 0, sleepWritten: 0, skipped };
+  }
+
+  // First real data wins the store outright — see the header.
+  purgeFixtureData();
+
+  const store = healthStore();
+  const samplesWritten = store.ingestSamples(samples);
+  const sleepWritten = store.ingestSleep(sleep);
+  if (samplesWritten > 0 || sleepWritten > 0) markLiveData();
+
+  // ONLY here. Both store writes have returned, so the records are durable.
+  // If either threw, or the process died above this line, nothing is cleared
+  // and the same records arrive again next tick - which costs one repeated
+  // ingest (a no-op, the store refuses identical re-writes) instead of losing
+  // a night. Note `samplesWritten === 0` is NOT a failure: it means the store
+  // already held all of it, which is the steady state this change creates.
+  consumeUpTo(communicator, watermark);
+
+  console.log(
+    `health live: ${size} records -> ${samplesWritten} samples, ${sleepWritten} sleep` +
+      (skipped.length ? `, ${skipped.length} skipped` : ""),
+  );
+  return { seen: size, samplesWritten, sleepWritten, skipped };
+}
+
+/**
+ * Ask the ring for a fresh pull now, rather than waiting out the automatic
+ * 30-minute cycle. Returns immediately; the pull itself takes ~15s on the
+ * communicator's worker thread and lands through the next `syncLiveRecords()`.
+ *
+ * Throttled communicator-side to one a minute — see
+ * `requestRingHealthNow()`. Calling it on every open is fine.
+ */
+export function requestFreshPull(): void {
+  const communicator = activeCommunicator();
+  if (!communicator) return;
+  try {
+    communicator.requestRingHealthNow();
+  } catch (error) {
+    console.warn("health live: on-demand pull request failed", error);
+  }
+}
+
+/**
+ * Keep decoded records reaching disk whether or not a surface is open.
+ *
+ * Without this, records live only in the communicator's memory until the
+ * health app or phone page is opened, so a pull that lands while both are
+ * closed is lost if the process restarts first. The store dedupes, so this is
+ * a no-op whenever there is nothing new.
+ *
+ * Called once from `app.ts`. Idempotent.
+ */
+const BACKGROUND_SYNC_INTERVAL_MS = 60 * 1000;
+let backgroundSyncTimer: ReturnType<typeof setInterval> | null = null;
+
+export function startLiveHealthSync(): void {
+  if (backgroundSyncTimer) return;
+  backgroundSyncTimer = setInterval(() => {
+    try {
+      syncLiveRecords();
+    } catch (error) {
+      console.warn("health live: background sync failed", error);
+    }
+  }, BACKGROUND_SYNC_INTERVAL_MS);
+}
+
+/**
+ * Pull the ring on a wall-clock-aligned cadence: :01 and :31, every hour.
+ *
+ * Chris, 2026-09-12: *"I think we should be polling the ring on the 30 minute
+ * cycle (that was my intent, not a floor honestly)."* The 30-minute value in
+ * `RING_HEALTH_MIN_PULL_INTERVAL_MS` was always meant as a collection rhythm
+ * and got built as a throttle, so a connected, stable ring pulled never —
+ * nothing in the system drives a pull on a timer at all.
+ *
+ * Two reasons this is aligned to the wall clock rather than a plain interval:
+ *
+ * 1. **The ring's own step buckets close on 10-minute boundaries.** Pulling on
+ *    the boundary collects a just-closed bucket instead of a half-formed one.
+ * 2. **An elapsed timer drifts.** A pull at :07 sets the next at :37, then :07,
+ *    wandering away from the boundary it is supposed to track. Re-arming
+ *    against the clock each time cannot drift.
+ *
+ * The **one-minute offset is deliberate**: firing exactly at :00 risks catching
+ * the ring before it has finalised that bucket.
+ *
+ * This only *requests* a pull. The communicator still applies its own anti-spam
+ * floor, so an extra call here can never hammer the ring.
+ */
+const ALIGNED_PULL_MINUTES = [1, 31];
+let alignedPullTimer: ReturnType<typeof setTimeout> | null = null;
+
+function msUntilNextAlignedPull(now: Date): number {
+  const minutes = now.getMinutes();
+  const withinHour = ALIGNED_PULL_MINUTES.filter((m) => m > minutes);
+  // Next slot this hour, or the first slot of the next hour.
+  const target = withinHour.length ? withinHour[0] : ALIGNED_PULL_MINUTES[0] + 60;
+  const msIntoMinute = now.getSeconds() * 1000 + now.getMilliseconds();
+  return (target - minutes) * 60 * 1000 - msIntoMinute;
+}
+
+export function startAlignedRingPull(): void {
+  if (alignedPullTimer) return;
+  const arm = () => {
+    const delay = msUntilNextAlignedPull(new Date());
+    alignedPullTimer = setTimeout(() => {
+      alignedPullTimer = null;
+      try {
+        requestFreshPull();
+      } catch (error) {
+        console.warn("health live: aligned ring pull failed", error);
+      }
+      arm();                        // re-arm against the clock, never the elapsed time
+    }, delay);
+  };
+  arm();
+}
+
+/** Exported for tests — the scheduling arithmetic, with no timer attached. */
+export const __alignedPullInternals = { msUntilNextAlignedPull, ALIGNED_PULL_MINUTES };

--- a/app/health/health-phone-chart.ts
+++ b/app/health/health-phone-chart.ts
@@ -1,0 +1,101 @@
+/**
+ * The phone graph view's BITMAP, built without touching the phone.
+ *
+ * Same split, and for the same reason, as `health-glance.ts` is split out of
+ * the glasses app: `health-view-model.ts` owns the store reads, the measured
+ * box, the fold class and the `ImageSource` conversion - all NativeScript - and
+ * hands this file a size, a font and some already-selected data. What comes
+ * back is a `GrayImage`.
+ *
+ * The payoff is that `tools/health-preview.cjs` can render the phone chart at
+ * any width under plain node, which is how the narrow/wide layouts get checked
+ * without an emulator. It also means the chart the preview shows is built by
+ * the same function the phone calls, not a reimplementation of it.
+ */
+
+import { GrayImage, type UiFont } from "../graphics/image";
+import {
+  drawMetricChart,
+  drawSleepLanes,
+  drawSleepStackChart,
+  INK,
+} from "./health-chart";
+import type { RollupPoint, SampleMetric, SleepNight } from "./health-types";
+import type { SleepStageName } from "./sleep-stages";
+
+/**
+ * What to draw. Three shapes, because the redesign gave sleep two charts of
+ * its own that are not "a series of numbers over time":
+ *
+ *   - `metric`   the five measured types, banded or barred (unchanged)
+ *   - `nights`   sleep over a week/month/quarter: the diverging stacked bar
+ *   - `lanes`    sleep over ONE day: the four stage lanes, which is the same
+ *                view the glasses drill-down shows, so the two surfaces agree
+ *                about what "sleep, today" looks like
+ */
+export type PhoneChartContent =
+  | {
+      kind: "metric";
+      metric: SampleMetric;
+      points: readonly RollupPoint[];
+      mode: "band" | "bars";
+      xLabel: (point: RollupPoint, index: number) => string;
+    }
+  | {
+      kind: "nights";
+      nights: readonly SleepNight[];
+      xLabel: (night: SleepNight, index: number) => string;
+    }
+  | {
+      kind: "lanes";
+      bands: readonly { stage: SleepStageName | null; seconds: number }[];
+      laneText: (stage: SleepStageName) => { label: string; value: string };
+    };
+
+export type PhoneChartRequest = {
+  /** Pixels, already scaled by RENDER_SCALE. */
+  width: number;
+  height: number;
+  font: UiFont;
+  content: PhoneChartContent;
+};
+
+/** The inset between the bitmap's edge and the plot. */
+const INSET = 8;
+
+export function renderPhoneChart(request: PhoneChartRequest): GrayImage {
+  const { width, height, font, content } = request;
+  const image = new GrayImage(width, height, INK.background);
+  const rect = {
+    x: INSET,
+    y: INSET,
+    width: Math.max(8, width - INSET * 2),
+    height: Math.max(8, height - INSET * 2),
+  };
+
+  switch (content.kind) {
+    case "metric":
+      drawMetricChart(image, rect, {
+        metric: content.metric,
+        points: content.points,
+        font,
+        mode: content.mode,
+        xLabel: content.xLabel,
+      });
+      return image;
+    case "nights":
+      drawSleepStackChart(image, rect, {
+        nights: content.nights,
+        font,
+        xLabel: content.xLabel,
+      });
+      return image;
+    case "lanes":
+      drawSleepLanes(image, rect, {
+        bands: content.bands,
+        font,
+        laneText: content.laneText,
+      });
+      return image;
+  }
+}

--- a/app/health/health-seed.ts
+++ b/app/health/health-seed.ts
@@ -1,0 +1,137 @@
+/**
+ * Seeding the store with sample data, and the marker that keeps a screenshot
+ * of it honest.
+ *
+ * Without live ring hardware there is nothing in the store, and two empty
+ * screens prove nothing. So the preview build seeds `health-fixtures.ts`'
+ * generated data and drops `fixture-marker.json` beside it; both surfaces read
+ * `isFixtureData()` and show a "Sample data" badge whenever it is there.
+ *
+ * The badge is the point. A health screen full of plausible numbers with no
+ * provenance is the one artefact from this work that could be mistaken for a
+ * real capture later, so the marker travels with the data rather than living
+ * in someone's memory of how a screenshot was taken.
+ *
+ * Real ingest never writes the marker, so the first genuine sync leaves it
+ * exactly as it was - which is why `clearFixtures()` exists and why the live
+ * wiring should call it before its first write.
+ */
+
+import { File, knownFolders } from "@nativescript/core";
+
+import { buildFixtures, FIXTURE_VERSION } from "./health-fixtures";
+import { healthStore } from "./health-store-files";
+
+const MARKER_FILE = "fixture-marker.json";
+
+function markerPath(): string {
+  return `${knownFolders.documents().getFolder("health").path}/${MARKER_FILE}`;
+}
+
+type Marker = { version: number; seededAtMs: number; days: number };
+
+function readMarker(): Marker | null {
+  try {
+    if (!File.exists(markerPath())) return null;
+    const parsed = JSON.parse(File.fromPath(markerPath()).readTextSync()) as Marker;
+    return typeof parsed?.version === "number" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the store currently holds generated sample data. */
+export function isFixtureData(): boolean {
+  return readMarker() !== null;
+}
+
+/** Written by `health-live.ts` the first time real ring data lands. */
+const LIVE_FILE = "live-marker.json";
+
+function livePath(): string {
+  return `${knownFolders.documents().getFolder("health").path}/${LIVE_FILE}`;
+}
+
+/** True once this install has ever stored a record decoded off the ring. */
+export function hasLiveData(): boolean {
+  try {
+    return File.exists(livePath());
+  } catch {
+    return false;
+  }
+}
+
+/** Record that real data has been stored. Called by the live ingest path. */
+export function markLiveData(): void {
+  try {
+    File.fromPath(livePath()).writeTextSync(JSON.stringify({ firstAtMs: Date.now() }));
+  } catch (error) {
+    console.warn("health live marker write failed", error);
+  }
+}
+
+/**
+ * Delete every stored sample, session and rollup, and the fixture badge with
+ * them. Called before the first genuine ingest.
+ *
+ * `clearFixtureMarker()` is not enough on its own and never was: dropping the
+ * badge while leaving 45 days of generated samples in the store produces
+ * exactly the artefact this file's header warns about — plausible numbers with
+ * no provenance, now unlabelled. Real data gets a clean store or none.
+ */
+export function purgeFixtureData(): void {
+  if (!isFixtureData()) return;
+  try {
+    const folder = knownFolders.documents().getFolder("health");
+    for (const entity of folder.getEntitiesSync()) {
+      const name = entity.name;
+      const isStoreFile =
+        (name.startsWith("samples-") && name.endsWith(".jsonl")) ||
+        name === "sleep.jsonl" ||
+        name === "rollups.json";
+      if (isStoreFile) File.fromPath(entity.path).removeSync();
+    }
+  } catch (error) {
+    console.warn("health fixture purge failed", error);
+  }
+  clearFixtureMarker();
+}
+
+/**
+ * Seed sample data if none is present, or if the generator has changed since
+ * the last seed. A no-op once seeded, so it is safe to call on every launch.
+ *
+ * Refuses outright once real ring data has ever been stored — otherwise a
+ * version bump to the generator would inject fixtures back on top of a real
+ * history, which is worse than an empty screen.
+ */
+export function seedFixturesIfNeeded(days = 45): boolean {
+  if (hasLiveData()) return false;
+  const marker = readMarker();
+  if (marker && marker.version === FIXTURE_VERSION && marker.days >= days) return false;
+  return seedFixtures(days);
+}
+
+export function seedFixtures(days = 45): boolean {
+  try {
+    const store = healthStore();
+    const { samples, sleep } = buildFixtures({ days, nowMs: Date.now() });
+    store.ingestSamples(samples);
+    store.ingestSleep(sleep);
+    const marker: Marker = { version: FIXTURE_VERSION, seededAtMs: Date.now(), days };
+    File.fromPath(markerPath()).writeTextSync(JSON.stringify(marker));
+    return true;
+  } catch (error) {
+    console.warn("health fixture seed failed", error);
+    return false;
+  }
+}
+
+/** Drop the marker. Call before the first real ingest. */
+export function clearFixtureMarker(): void {
+  try {
+    if (File.exists(markerPath())) File.fromPath(markerPath()).removeSync();
+  } catch (error) {
+    console.warn("health fixture marker clear failed", error);
+  }
+}

--- a/app/health/health-store-files.ts
+++ b/app/health/health-store-files.ts
@@ -1,0 +1,86 @@
+/**
+ * The real, on-device backing for `HealthStore`: files under the app's
+ * documents folder, using the same `@nativescript/core` File API that
+ * `open-apps-persistence.ts` already uses for the open-window list.
+ *
+ * Split out from `health-store.ts` purely so that module can stay free of
+ * NativeScript imports and run under plain node in `tests/`; all the logic
+ * worth testing is over there.
+ */
+
+import { File, Folder, knownFolders } from "@nativescript/core";
+
+import { HealthStore, type HealthStorageBackend } from "./health-store";
+
+const FOLDER_NAME = "health";
+
+function healthFolder(): Folder {
+  return knownFolders.documents().getFolder(FOLDER_NAME);
+}
+
+function pathFor(name: string): string {
+  return `${healthFolder().path}/${name}`;
+}
+
+class FileBackend implements HealthStorageBackend {
+  exists(name: string): boolean {
+    try {
+      return File.exists(pathFor(name));
+    } catch {
+      return false;
+    }
+  }
+
+  read(name: string): string | null {
+    try {
+      if (!File.exists(pathFor(name))) return null;
+      return File.fromPath(pathFor(name)).readTextSync();
+    } catch (error) {
+      console.warn(`health store read failed (${name})`, error);
+      return null;
+    }
+  }
+
+  append(name: string, text: string): void {
+    try {
+      // `File.fromPath` creates the file when it is missing, and
+      // `appendTextSync` is the durable single-call append - deliberately not
+      // read-modify-write, which would put every record already on disk at
+      // risk on every new one.
+      File.fromPath(pathFor(name)).appendTextSync(text, (error) => {
+        console.warn(`health store append failed (${name})`, error);
+      });
+    } catch (error) {
+      console.warn(`health store append threw (${name})`, error);
+    }
+  }
+
+  write(name: string, text: string): void {
+    try {
+      File.fromPath(pathFor(name)).writeTextSync(text, (error) => {
+        console.warn(`health store write failed (${name})`, error);
+      });
+    } catch (error) {
+      console.warn(`health store write threw (${name})`, error);
+    }
+  }
+
+  list(): string[] {
+    try {
+      return healthFolder()
+        .getEntitiesSync()
+        .map((entity) => entity.name);
+    } catch (error) {
+      console.warn("health store list failed", error);
+      return [];
+    }
+  }
+}
+
+let store: HealthStore | null = null;
+
+/** The app's one health store. Created on first use. */
+export function healthStore(): HealthStore {
+  if (!store) store = new HealthStore(new FileBackend());
+  return store;
+}

--- a/app/health/health-store.ts
+++ b/app/health/health-store.ts
@@ -1,0 +1,433 @@
+/**
+ * Durable local storage for decoded ring health records.
+ *
+ * ## Why this exists at all, and why it is not a cache
+ *
+ * Live testing on 2026-09-10 found that the ring appears to advance its own
+ * delivery watermark when it sends the RSP to a health request, whether or not
+ * the DATA page that should follow ever arrives - so a request that loses the
+ * race can PERMANENTLY DISCARD backlog, silently, with no error anywhere in
+ * the protocol (implement-return, section 11). The practical consequence:
+ * the moment a record is successfully decoded may be the only moment it is
+ * ever available. It has to hit durable storage right then.
+ *
+ * The existing `ringHealthRecords` list on `FaceclawBleCommunicator` is
+ * explicitly a capped, ephemeral ring buffer (256 records, oldest dropped) and
+ * is not a store. This is the store.
+ *
+ * ## The layout, and why it is shaped this way
+ *
+ *   health/samples-YYYY-MM.jsonl   append-only, one JSON object per line
+ *   health/sleep.jsonl             append-only, one session per line
+ *   health/rollups.json            DERIVED daily rollups - a rebuildable cache
+ *
+ * The raw shards are the truth and are never rewritten in place, only appended
+ * to. That is the property the paragraph above demands: a crash, a bad parse,
+ * or a bug in the rollup code can never destroy a record that was once
+ * received, because nothing ever rewrites the file that holds it.
+ *
+ * `rollups.json` is the answer to "pre-aggregate on write, or aggregate on
+ * render?" - and the answer is BOTH, at different layers, because they are
+ * asked by different screens:
+ *
+ *   - The glasses glance and the by-hour charts want one day at fine
+ *     resolution. That comes from raw shards, aggregated on render. At ~360
+ *     samples a day the work is trivial, and it stays exact.
+ *   - The by-day charts want weeks or months. Aggregating those on render
+ *     means parsing every shard in the range - about 9 MB a year of JSONL, and
+ *     growing without bound. So daily rollups are maintained on write and
+ *     served straight from this one small file, and a quarter-long chart never
+ *     opens a shard at all.
+ *
+ * Because the rollup file is derived, it carries no risk: if it is missing,
+ * corrupt, or written by an older version, `rebuildRollups()` regenerates it
+ * from the shards. Deleting it is always safe.
+ *
+ * ## No new dependency
+ *
+ * SQLite is not a dependency of this project and adding one for this would be
+ * the largest change in the feature. Everything the phone view needs is a
+ * key-ordered scan over a few tens of thousands of rows, which is what the
+ * above does with the `File` API already used by `open-apps-persistence.ts`
+ * for the same kind of job.
+ *
+ * This module has NO NativeScript imports - the filesystem arrives through
+ * `HealthStorageBackend` - so its durability and dedupe semantics run under
+ * plain node in `tests/health-store.test.cjs`. The real backend is
+ * `health-store-files.ts`.
+ */
+
+import {
+  type HealthSample,
+  type Rollup,
+  type SampleMetric,
+  type SleepSession,
+  SAMPLE_METRICS,
+  monthKey,
+  rollupOf,
+  startOfLocalDay,
+} from "./health-types";
+
+export interface HealthStorageBackend {
+  exists(name: string): boolean;
+  read(name: string): string | null;
+  /** Must create the file if absent. Durable before returning. */
+  append(name: string, text: string): void;
+  write(name: string, text: string): void;
+  /** Every file in the health folder. Used to rebuild the rollup cache. */
+  list(): string[];
+}
+
+const SAMPLE_PREFIX = "samples-";
+const SAMPLE_SUFFIX = ".jsonl";
+const SLEEP_FILE = "sleep.jsonl";
+const ROLLUP_FILE = "rollups.json";
+const ROLLUP_VERSION = 1;
+
+/** On-disk sample line. Short keys: this is the file that grows. */
+type SampleLine = {
+  m: SampleMetric;
+  t: number;
+  s: number;
+  n: number;
+  x: number;
+  a: number;
+  u: number;
+};
+
+type RollupFile = {
+  version: number;
+  /** `YYYY-MM-DD` -> metric -> rollup. */
+  days: Record<string, Partial<Record<SampleMetric, Rollup>>>;
+};
+
+function sampleKey(sample: { metric: SampleMetric; startMs: number; spanMs: number }): string {
+  return `${sample.metric}|${sample.startMs}|${sample.spanMs}`;
+}
+
+function dayKey(ms: number): string {
+  const date = new Date(startOfLocalDay(ms));
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function shardName(ms: number): string {
+  return `${SAMPLE_PREFIX}${monthKey(ms)}${SAMPLE_SUFFIX}`;
+}
+
+export class HealthStore {
+  /** Shard name -> dedupe key -> sample. Loaded lazily, per shard. */
+  private readonly shards = new Map<string, Map<string, HealthSample>>();
+  private sleep: SleepSession[] | null = null;
+  private rollups: RollupFile | null = null;
+
+  constructor(private readonly backend: HealthStorageBackend) {}
+
+  // -------------------------------------------------------------------------
+  // Writing
+
+  /**
+   * Store decoded samples. Durable before this returns.
+   *
+   * Returns how many were genuinely new or changed. Re-storing a bucket that
+   * is already held is a no-op on disk, which matters because the live poller
+   * re-requests the current hour every 30 minutes and would otherwise append a
+   * duplicate line each time.
+   *
+   * ## This no-op is real, and it is the ONLY place it needs to be
+   *
+   * Re-checked 2026-09-12 while chasing a shard that reached 22k lines in a
+   * day. The suspicion was that identical re-writes were being appended; they
+   * were not. `sameSample` below compares every stored field, `spanMs` is part
+   * of the key, and an unchanged sample never reaches `append`.
+   *
+   * What was actually appending was a genuinely CHANGING value: the steps
+   * ledger merged overlapping records with last-write-wins, and those records
+   * disagreed about each bucket's calorie fields, so one day's calorie total
+   * ping-ponged 643 <-> 671 and wrote two new lines every sync cycle. An
+   * append-only store recording a value that really does flip-flop is correct
+   * behaviour; the fix belonged upstream, in `health-live.ts`' merge, and is
+   * there now (max-by-index, order-independent).
+   *
+   * So: do NOT add a second dedupe layer at a caller or in the file backend.
+   * If the shard grows again, the value is changing and the question is why.
+   */
+  ingestSamples(samples: readonly HealthSample[]): number {
+    const byShard = new Map<string, HealthSample[]>();
+    for (const sample of samples) {
+      if (!Number.isFinite(sample.startMs) || sample.spanMs <= 0) continue;
+      const name = shardName(sample.startMs);
+      const shard = this.loadShard(name);
+      const key = sampleKey(sample);
+      const existing = shard.get(key);
+      if (existing && sameSample(existing, sample)) continue;
+      shard.set(key, sample);
+      const pending = byShard.get(name);
+      if (pending) pending.push(sample);
+      else byShard.set(name, [sample]);
+    }
+    let written = 0;
+    for (const [name, list] of byShard) {
+      const text = list.map((sample) => `${JSON.stringify(toLine(sample))}\n`).join("");
+      this.backend.append(name, text);
+      written += list.length;
+    }
+    if (written > 0) this.updateRollupsFor(samples);
+    return written;
+  }
+
+  /**
+   * Store sleep sessions. Durable before this returns.
+   *
+   * Deduped on the session's own start time, so a night re-delivered by a
+   * later sync replaces rather than duplicates.
+   */
+  ingestSleep(sessions: readonly SleepSession[]): number {
+    const held = this.loadSleep();
+    const fresh: SleepSession[] = [];
+    for (const session of sessions) {
+      const index = held.findIndex(
+        (candidate) =>
+          candidate.startMs === session.startMs && candidate.timeResolved === session.timeResolved,
+      );
+      if (index >= 0) {
+        if (JSON.stringify(held[index]) === JSON.stringify(session)) continue;
+        held[index] = session;
+      } else {
+        held.push(session);
+      }
+      fresh.push(session);
+    }
+    if (fresh.length > 0) {
+      this.backend.append(SLEEP_FILE, fresh.map((s) => `${JSON.stringify(s)}\n`).join(""));
+    }
+    return fresh.length;
+  }
+
+  // -------------------------------------------------------------------------
+  // Reading
+
+  /** Every stored sample overlapping [startMs, endMs). Exact - reads shards. */
+  samplesInRange(startMs: number, endMs: number): HealthSample[] {
+    const out: HealthSample[] = [];
+    for (const name of this.shardNamesInRange(startMs, endMs)) {
+      for (const sample of this.loadShard(name).values()) {
+        if (sample.startMs >= startMs && sample.startMs < endMs) out.push(sample);
+      }
+    }
+    out.sort((a, b) => a.startMs - b.startMs);
+    return out;
+  }
+
+  /** Sleep sessions, newest first. */
+  sleepSessions(): SleepSession[] {
+    return this.loadSleep().slice().sort((a, b) => b.startMs - a.startMs);
+  }
+
+  /**
+   * Daily rollups over a range, served from the derived cache.
+   *
+   * This is the path a month- or quarter-long chart takes, and it deliberately
+   * never opens a sample shard. A day with no entry comes back absent, and the
+   * caller renders a gap.
+   */
+  dailyRollups(metric: SampleMetric, startMs: number, endMs: number): Map<number, Rollup> {
+    const file = this.loadRollups();
+    const out = new Map<number, Rollup>();
+    let cursor = startOfLocalDay(startMs);
+    let guard = 0;
+    while (cursor < endMs && guard < 2000) {
+      guard += 1;
+      const entry = file.days[dayKey(cursor)]?.[metric];
+      if (entry) out.set(cursor, entry);
+      const next = new Date(cursor);
+      next.setDate(next.getDate() + 1);
+      cursor = next.getTime();
+    }
+    return out;
+  }
+
+  /** Local midnight of the earliest day with any stored data, or null. */
+  earliestDayMs(): number | null {
+    const file = this.loadRollups();
+    const keys = Object.keys(file.days).sort();
+    if (keys.length === 0) return null;
+    const parts = keys[0]!.split("-").map(Number);
+    return new Date(parts[0]!, parts[1]! - 1, parts[2]!).getTime();
+  }
+
+  /** How many sample rows are held, across every loaded shard. */
+  loadedSampleCount(): number {
+    let total = 0;
+    for (const shard of this.shards.values()) total += shard.size;
+    return total;
+  }
+
+  // -------------------------------------------------------------------------
+  // The derived cache
+
+  /**
+   * Rebuild `rollups.json` from the raw shards. Safe to call at any time; the
+   * recovery path when the cache is missing, corrupt or from an older version.
+   */
+  rebuildRollups(): void {
+    const days: RollupFile["days"] = {};
+    const perDay = new Map<string, Map<SampleMetric, HealthSample[]>>();
+    for (const name of this.backend.list()) {
+      if (!name.startsWith(SAMPLE_PREFIX) || !name.endsWith(SAMPLE_SUFFIX)) continue;
+      for (const sample of this.loadShard(name).values()) {
+        const key = dayKey(sample.startMs);
+        let byMetric = perDay.get(key);
+        if (!byMetric) {
+          byMetric = new Map();
+          perDay.set(key, byMetric);
+        }
+        const list = byMetric.get(sample.metric);
+        if (list) list.push(sample);
+        else byMetric.set(sample.metric, [sample]);
+      }
+    }
+    for (const [key, byMetric] of perDay) {
+      const entry: Partial<Record<SampleMetric, Rollup>> = {};
+      for (const metric of SAMPLE_METRICS) {
+        const rolled = rollupOf(byMetric.get(metric) ?? []);
+        if (rolled) entry[metric] = rolled;
+      }
+      days[key] = entry;
+    }
+    this.rollups = { version: ROLLUP_VERSION, days };
+    this.persistRollups();
+  }
+
+  private updateRollupsFor(samples: readonly HealthSample[]): void {
+    const file = this.loadRollups();
+    const touched = new Set<string>();
+    for (const sample of samples) touched.add(dayKey(sample.startMs));
+    for (const key of touched) {
+      const parts = key.split("-").map(Number);
+      const dayStart = new Date(parts[0]!, parts[1]! - 1, parts[2]!).getTime();
+      const dayEnd = new Date(parts[0]!, parts[1]! - 1, parts[2]! + 1).getTime();
+      const inDay = this.samplesInRange(dayStart, dayEnd);
+      const entry: Partial<Record<SampleMetric, Rollup>> = {};
+      for (const metric of SAMPLE_METRICS) {
+        const rolled = rollupOf(inDay.filter((sample) => sample.metric === metric));
+        if (rolled) entry[metric] = rolled;
+      }
+      file.days[key] = entry;
+    }
+    this.persistRollups();
+  }
+
+  private persistRollups(): void {
+    if (!this.rollups) return;
+    this.backend.write(ROLLUP_FILE, JSON.stringify(this.rollups));
+  }
+
+  // -------------------------------------------------------------------------
+  // Loading
+
+  private shardNamesInRange(startMs: number, endMs: number): string[] {
+    const names: string[] = [];
+    const cursor = new Date(startOfLocalDay(startMs));
+    cursor.setDate(1);
+    let guard = 0;
+    while (cursor.getTime() < endMs && guard < 240) {
+      guard += 1;
+      names.push(`${SAMPLE_PREFIX}${monthKey(cursor.getTime())}${SAMPLE_SUFFIX}`);
+      cursor.setMonth(cursor.getMonth() + 1);
+    }
+    return names;
+  }
+
+  private loadShard(name: string): Map<string, HealthSample> {
+    const held = this.shards.get(name);
+    if (held) return held;
+    const shard = new Map<string, HealthSample>();
+    this.shards.set(name, shard);
+    const text = this.backend.exists(name) ? this.backend.read(name) : null;
+    if (!text) return shard;
+    for (const line of text.split("\n")) {
+      if (line.length === 0) continue;
+      const sample = fromLine(line);
+      // Later lines win: an append is how a re-synced bucket is corrected.
+      if (sample) shard.set(sampleKey(sample), sample);
+    }
+    return shard;
+  }
+
+  private loadSleep(): SleepSession[] {
+    if (this.sleep) return this.sleep;
+    const sessions: SleepSession[] = [];
+    const text = this.backend.exists(SLEEP_FILE) ? this.backend.read(SLEEP_FILE) : null;
+    if (text) {
+      for (const line of text.split("\n")) {
+        if (line.length === 0) continue;
+        try {
+          const parsed = JSON.parse(line) as SleepSession;
+          if (typeof parsed?.startMs !== "number") continue;
+          const index = sessions.findIndex((s) => s.startMs === parsed.startMs);
+          if (index >= 0) sessions[index] = parsed;
+          else sessions.push(parsed);
+        } catch {
+          // One unreadable line must not cost the rest of the file.
+        }
+      }
+    }
+    this.sleep = sessions;
+    return sessions;
+  }
+
+  private loadRollups(): RollupFile {
+    if (this.rollups) return this.rollups;
+    const text = this.backend.exists(ROLLUP_FILE) ? this.backend.read(ROLLUP_FILE) : null;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as RollupFile;
+        if (parsed?.version === ROLLUP_VERSION && parsed.days) {
+          this.rollups = parsed;
+          return parsed;
+        }
+      } catch {
+        // Falls through to a rebuild - the cache is always reconstructible.
+      }
+    }
+    this.rollups = { version: ROLLUP_VERSION, days: {} };
+    this.rebuildRollups();
+    return this.rollups;
+  }
+}
+
+function sameSample(a: HealthSample, b: HealthSample): boolean {
+  return a.min === b.min && a.max === b.max && a.avg === b.avg && a.total === b.total;
+}
+
+function toLine(sample: HealthSample): SampleLine {
+  return {
+    m: sample.metric,
+    t: sample.startMs,
+    s: sample.spanMs,
+    n: sample.min,
+    x: sample.max,
+    a: sample.avg,
+    u: sample.total,
+  };
+}
+
+function fromLine(line: string): HealthSample | null {
+  try {
+    const parsed = JSON.parse(line) as SampleLine;
+    if (typeof parsed?.t !== "number" || typeof parsed?.m !== "string") return null;
+    return {
+      metric: parsed.m,
+      startMs: parsed.t,
+      spanMs: parsed.s,
+      min: parsed.n,
+      max: parsed.x,
+      avg: parsed.a,
+      total: parsed.u,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/health/health-types.ts
+++ b/app/health/health-types.ts
@@ -1,0 +1,231 @@
+/**
+ * The health record shapes, normalised for storage and display.
+ *
+ * These mirror `RingProtocol.java`'s `HourlyRecord` / `StepsRecord` /
+ * `SleepRecord` (on the `ring-health-protocol` branch) but deliberately are
+ * NOT the same types: the Java types are wire-shaped - raw hour indices, raw
+ * stage ids, ring-relative timestamps, a per-page anchor that may be absent.
+ * Everything here is already resolved into wall-clock time, or explicitly
+ * marked as not resolvable. The conversion is `fromRingRecords()` in
+ * `health-ingest.ts`, which is the only place that has to know about the wire.
+ *
+ * Keeping the two apart is what lets this app's storage and UI be built and
+ * tested with no BLE anywhere near them.
+ */
+
+/** The five metrics the phone view can graph. */
+export type SeriesMetric = "heartRate" | "spo2" | "hrv" | "steps" | "sleep";
+
+/** Metrics stored as bucketed samples. Sleep is per-session and excluded. */
+export type SampleMetric = "heartRate" | "spo2" | "hrv" | "steps" | "calories";
+
+export const SAMPLE_METRICS: readonly SampleMetric[] = [
+  "heartRate",
+  "spo2",
+  "hrv",
+  "steps",
+  "calories",
+];
+
+/** Metrics whose bucket value is a SUM over the bucket, not a measurement. */
+export const CUMULATIVE_METRICS: readonly SampleMetric[] = ["steps", "calories"];
+
+export function isCumulative(metric: SampleMetric): boolean {
+  return CUMULATIVE_METRICS.includes(metric);
+}
+
+export const HOUR_MS = 3_600_000;
+export const TEN_MINUTES_MS = 600_000;
+export const DAY_MS = 86_400_000;
+
+/**
+ * One stored bucket.
+ *
+ * `min`/`max`/`avg` are what the ring reports for the physiological metrics.
+ * For the cumulative ones (steps, calories) the ring reports a single count
+ * per bucket, so all three carry that count and `total` carries it as well -
+ * which keeps one shape for everything and lets a rollup sum `total` while
+ * banding `min`/`max` without special-casing the reader.
+ *
+ * `startMs` is the LOCAL wall-clock start of the bucket. A record whose time
+ * could not be resolved (a backlog page with no anchor; see the decode doc's
+ * section 4) is not stored at all rather than stored with an invented time -
+ * see `health-ingest.ts`.
+ */
+export type HealthSample = {
+  metric: SampleMetric;
+  startMs: number;
+  spanMs: number;
+  min: number;
+  max: number;
+  avg: number;
+  total: number;
+};
+
+/**
+ * One sleep session.
+ *
+ * All five duration fields come from NAMED byte offsets in the record and need
+ * no stage-id mapping (see `sleep-stages.ts`). `segments` is the hypnogram and
+ * carries RAW stage ids - resolve them through `stageNameForId`, never inline.
+ *
+ * `timeResolved` matters and is not decoration: the decode found that the
+ * ring's `start_ts`/`end_ts` are ring-relative seconds, not Unix time, and
+ * that nothing in the record dates the session (decode section 6, "genuinely
+ * unresolved"). Even's own app gets this wrong - one exported row is stamped
+ * 1979. When we cannot anchor a session we say so rather than plotting it at a
+ * time we made up.
+ */
+export type SleepSession = {
+  /** Local midnight of the day the session is attributed to (the wake-up day). */
+  dayStartMs: number;
+  startMs: number;
+  endMs: number;
+  totalSec: number;
+  wakeSec: number;
+  remSec: number;
+  lightSec: number;
+  deepSec: number;
+  segments: readonly SleepSegment[];
+  /** False when startMs/endMs are ring-relative and could not be anchored. */
+  timeResolved: boolean;
+};
+
+export type SleepSegment = {
+  /** RAW ring stage id, 0-3. Resolve via `stageNameForId`. */
+  stageId: number;
+  halfMinutes: number;
+};
+
+/**
+ * One night's stage breakdown, in seconds, positioned on the day axis.
+ *
+ * This is what the diverging nightly sleep chart plots (week / month / 3
+ * months). It is a separate shape from `RollupPoint` because a night is not a
+ * rollup of anything - it has four named parts that stack, three up and one
+ * down, and flattening it to a single `sum` is exactly the information the
+ * redesigned chart exists to stop throwing away.
+ */
+export type SleepNight = {
+  /** Local midnight of the day the session is attributed to (the wake-up day). */
+  startMs: number;
+  /** False when no session was recorded for this day - drawn as a gap. */
+  hasData: boolean;
+  deepSec: number;
+  remSec: number;
+  lightSec: number;
+  wakeSec: number;
+};
+
+/** A min/max/avg/sum rollup over some window. `count` is buckets contributing. */
+export type Rollup = {
+  min: number;
+  max: number;
+  avg: number;
+  sum: number;
+  count: number;
+};
+
+/** A rollup positioned on the time axis - what the charts actually plot. */
+export type RollupPoint = Rollup & {
+  /** Local wall-clock start of the window this rollup covers. */
+  startMs: number;
+  spanMs: number;
+};
+
+export function emptyRollup(): Rollup {
+  return { min: 0, max: 0, avg: 0, sum: 0, count: 0 };
+}
+
+/** Combine samples into one rollup. Returns null when nothing contributed. */
+export function rollupOf(samples: readonly HealthSample[]): Rollup | null {
+  if (samples.length === 0) return null;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let sum = 0;
+  let weighted = 0;
+  for (const sample of samples) {
+    if (sample.min < min) min = sample.min;
+    if (sample.max > max) max = sample.max;
+    sum += sample.total;
+    weighted += sample.avg;
+  }
+  return {
+    min,
+    max,
+    avg: weighted / samples.length,
+    sum,
+    count: samples.length,
+  };
+}
+
+export const METRIC_LABELS: Readonly<Record<SeriesMetric, string>> = {
+  heartRate: "Heart rate",
+  spo2: "Blood oxygen",
+  hrv: "HRV",
+  steps: "Steps",
+  sleep: "Sleep",
+};
+
+export const METRIC_UNITS: Readonly<Record<SeriesMetric, string>> = {
+  heartRate: "bpm",
+  spo2: "%",
+  hrv: "ms",
+  steps: "",
+  sleep: "h",
+};
+
+/**
+ * The same two maps over SampleMetric rather than SeriesMetric.
+ *
+ * These exist because the two enums differ at both ends: the phone GRAPHS
+ * sleep (which is not a sample metric) and the glasses drill-down walks
+ * calories (which is not a series metric, because the phone never got a
+ * calories chart). A screen that iterates the sample metrics needs a label for
+ * all five, so it gets its own map instead of special-casing the missing one.
+ */
+export const SAMPLE_METRIC_LABELS: Readonly<Record<SampleMetric, string>> = {
+  heartRate: "Heart rate",
+  spo2: "Blood oxygen",
+  hrv: "HRV",
+  steps: "Steps",
+  calories: "Calories",
+};
+
+export const SAMPLE_METRIC_UNITS: Readonly<Record<SampleMetric, string>> = {
+  heartRate: "bpm",
+  spo2: "%",
+  hrv: "ms",
+  steps: "",
+  calories: "kcal",
+};
+
+/** The short form the glance uses, where a column is ~300px wide. */
+export const SAMPLE_METRIC_SHORT_LABELS: Readonly<Record<SampleMetric, string>> = {
+  heartRate: "HR",
+  spo2: "SpO2",
+  hrv: "HRV",
+  steps: "Steps",
+  calories: "Calories",
+};
+
+/** Local midnight of the day containing `ms`. */
+export function startOfLocalDay(ms: number): number {
+  const date = new Date(ms);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+/** Local top-of-hour containing `ms`. */
+export function startOfLocalHour(ms: number): number {
+  const date = new Date(ms);
+  date.setMinutes(0, 0, 0);
+  return date.getTime();
+}
+
+/** `YYYY-MM`, in local time - the storage shard key. */
+export function monthKey(ms: number): string {
+  const date = new Date(ms);
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  return `${date.getFullYear()}-${month}`;
+}

--- a/app/health/sleep-stages.ts
+++ b/app/health/sleep-stages.ts
@@ -1,0 +1,93 @@
+/**
+ * THE RING'S SLEEP STAGE-TYPE IDS — the single place the 0-3 -> stage mapping
+ * is decided. If this ever turns out wrong, this file is the whole fix.
+ *
+ * ## What the ring sends
+ *
+ * A `06:01` sleep record carries two independent descriptions of the same
+ * night (see the protocol decode, section 6):
+ *
+ *   1. Five NAMED per-stage totals at fixed byte offsets - `total_time`,
+ *      `wake_time`, `rem_time`, `light_time`, `deep_time`. These are named,
+ *      not guessed: the decode reproduced a whole exported row byte-for-byte
+ *      from them, so a percentage computed from these fields needs no mapping
+ *      at all and is not affected by anything in this file.
+ *
+ *   2. A segment array of `[stage_type, half_minutes]` pairs - the hypnogram,
+ *      the shape of the night. `stage_type` is a raw 0-3 id, and *which* id is
+ *      which stage was the open question this file answers.
+ *
+ * So: STAGE PERCENTAGES DO NOT DEPEND ON THIS MAPPING. Only the hypnogram
+ * strip does. `health-derive.ts` computes percentages from the named totals
+ * and never consults `STAGE_NAME_BY_ID` for them.
+ *
+ * ## How the mapping was determined
+ *
+ * The implementation return doc listed this as guess #3 - "never cracked",
+ * expected to need a live-hardware comparison against Even's own app after a
+ * night's sleep. It did not, because that comparison was already sitting in
+ * the exported history: the export IS Even's app's own report, and its
+ * `rem_time`/`light_time`/`deep_time`/`wake_time` columns are Even's own
+ * labels for the same night whose raw segment array sits in the same row.
+ *
+ * Cross-check performed 2026-09-10 over all 34 exported sessions: for each
+ * session, sum `half_minutes * 30` per stage id and ask which named total it
+ * equals.
+ *
+ *   stage id 0 -> wake_time    34/34 sessions, no other total matched
+ *   stage id 1 -> rem_time     34/34 sessions, no other total matched
+ *   stage id 2 -> light_time   34/34 sessions, no other total matched
+ *   stage id 3 -> deep_time    34/34 sessions, no other total matched
+ *
+ * Not one session produced an ambiguous match (an id equalling two totals) or
+ * an unmatched id, and the decode's own sum identity
+ * (`sum(half_minutes) * 30 == total_time + wake_time`) held in all 34.
+ *
+ * ## Why it is still marked unconfirmed
+ *
+ * `STAGE_MAPPING_CONFIRMED` stays `false` until the same result is seen on a
+ * record faceclaw decoded off the wire ITSELF, rather than one Even's app
+ * exported. The arithmetic above is strong evidence about what the *ids mean*,
+ * but every session it was computed from reached the CSV through Even's app,
+ * so it cannot rule out that the app relabels ids on the way in. That is a
+ * narrow doubt, and the live check Chris planned still closes it in one night.
+ *
+ * While this is `false` the UI labels the hypnogram as unconfirmed rather than
+ * asserting "this band is REM"; see `health-chart.ts`. Flipping it to `true`
+ * is the whole of the change once a live record agrees.
+ */
+
+export type SleepStageName = "wake" | "rem" | "light" | "deep";
+
+/** Raw `stage_type` id -> stage. See this file's header for the evidence. */
+export const STAGE_NAME_BY_ID: Readonly<Record<number, SleepStageName>> = {
+  0: "wake",
+  1: "rem",
+  2: "light",
+  3: "deep",
+};
+
+/**
+ * False until a record faceclaw decoded off the wire itself confirms the
+ * mapping above. Read by the UI, which softens its stage labels while it is
+ * false. Flip to `true` after a live cross-check agrees.
+ */
+export const STAGE_MAPPING_CONFIRMED = false;
+
+/** The order stages are stacked/listed in, deepest sleep last. */
+export const STAGE_DISPLAY_ORDER: readonly SleepStageName[] = ["wake", "rem", "light", "deep"];
+
+export function stageNameForId(stageId: number): SleepStageName | null {
+  return STAGE_NAME_BY_ID[stageId] ?? null;
+}
+
+/** Human label for a stage, hedged while the mapping is unconfirmed. */
+export function stageLabel(stage: SleepStageName): string {
+  const labels: Record<SleepStageName, string> = {
+    wake: "Awake",
+    rem: "REM",
+    light: "Light",
+    deep: "Deep",
+  };
+  return labels[stage];
+}

--- a/notes/ring-protocol-selftest/RingProtocolSelfTest.java
+++ b/notes/ring-protocol-selftest/RingProtocolSelfTest.java
@@ -1,0 +1,483 @@
+package com.faceclaw.app;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Standalone self-test for {@link RingProtocol}. No Android APIs and no
+ * hardware: every byte-manipulation path is exercised against either frames
+ * copied from the reference capture or synthetic bodies built from the spec's
+ * field layout.
+ *
+ * <pre>
+ *   javac -d /tmp/rpt App_Resources/Android/src/main/java/com/faceclaw/app/g2protocol/RingProtocol.java \
+ *                     notes/ring-protocol-selftest/RingProtocolSelfTest.java
+ *   java -cp /tmp/rpt com.faceclaw.app.RingProtocolSelfTest
+ * </pre>
+ *
+ * <p>The captured frames reproduced below are requests and page-ACKs only.
+ * Those carry a nonce, a command id and a sequence number — no biometric
+ * values. No captured DATA page appears here, deliberately.
+ */
+public final class RingProtocolSelfTest {
+    private static int checks;
+    private static int failures;
+
+    public static void main(String[] args) {
+        testCrcAndRequestRoundTrip();
+        testFiveHealthRequests();
+        testPageAckAgainstCapture();
+        testParseRejectsGarbage();
+        testFragmentReassembly();
+        testHourlyDecode();
+        testStepsDecode();
+        testSleepDecodeAndIdentities();
+
+        System.out.println();
+        System.out.println(failures == 0
+            ? "PASS: all " + checks + " checks"
+            : "FAIL: " + failures + " of " + checks + " checks");
+        if (failures != 0) {
+            System.exit(1);
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    /**
+     * Rebuild captured request pkt 9166 from its decoded fields alone. If the
+     * CRC-32C parameters or the header layout are wrong by even one bit this
+     * cannot reproduce the captured bytes.
+     */
+    private static void testCrcAndRequestRoundTrip() {
+        section("CRC + request round-trip (captured pkt 9166)");
+        byte[] built = RingProtocol.buildRequest(
+            RingProtocol.CHAN_HEALTH,
+            RingProtocol.CMD_HI_HEART_RATE,
+            RingProtocol.CMD_LO_HEALTH,
+            0x06,
+            0x08ca);
+        expectHex("pkt 9166", "00db64265a64026406000001010c00ca08", built);
+
+        RingProtocol.Frame frame = RingProtocol.parse(built);
+        expect("parses back", frame != null && frame.crcOk);
+        expect("chan", frame.chan == RingProtocol.CHAN_HEALTH);
+        expect("kind REQ", frame.kind == RingProtocol.KIND_REQ);
+        expect("seq", frame.seq == 0x06);
+        expect("cmd 01:01", frame.cmdHi == 0x01 && frame.cmdLo == 0x01);
+        expect("payload is the 2-byte nonce", frame.payload.length == 2);
+
+        // A single flipped payload bit must invalidate the CRC.
+        byte[] tampered = built.clone();
+        tampered[15] ^= 0x01;
+        RingProtocol.Frame bad = RingProtocol.parse(tampered);
+        expect("tampered frame fails CRC", bad != null && !bad.crcOk);
+    }
+
+    /** The five ready-to-send health requests, seq=1, nonce=0. */
+    private static void testFiveHealthRequests() {
+        section("five health requests (spec section 9)");
+        String[][] expected = {
+            {"heart rate", "00450fe48f64026401000001010c000000"},
+            {"SpO2",       "000d3fd33364026401000002010c000000"},
+            {"HRV",        "00dc30615564026401000004010c000000"},
+            {"steps",      "00e4208c3e64026401000005010c000000"},
+            {"sleep",      "00ac10bb8264026401000006010c000000"},
+        };
+        int[] commands = {
+            RingProtocol.CMD_HI_HEART_RATE,
+            RingProtocol.CMD_HI_SPO2,
+            RingProtocol.CMD_HI_HRV,
+            RingProtocol.CMD_HI_STEPS,
+            RingProtocol.CMD_HI_SLEEP,
+        };
+        for (int i = 0; i < commands.length; i++) {
+            byte[] built = RingProtocol.buildHealthRequest(commands[i], 0x01, 0x0000);
+            expectHex(expected[i][0], expected[i][1], built);
+        }
+
+        // The convenience burst builder must produce the same first frame and
+        // then advance the shared sequence counter by one per frame.
+        List<byte[]> burst = RingProtocol.buildHealthRequestBurst(0x01, 0x0000);
+        expect("burst has five frames", burst.size() == 5);
+        expectHex("burst[0] == heart rate", expected[0][1], burst.get(0));
+        boolean seqRuns = true;
+        for (int i = 0; i < burst.size(); i++) {
+            RingProtocol.Frame f = RingProtocol.parse(burst.get(i));
+            if (f == null || !f.crcOk || f.seq != 0x01 + i) {
+                seqRuns = false;
+            }
+        }
+        expect("burst sequence numbers run 1..5 and all CRCs are valid", seqRuns);
+    }
+
+    /**
+     * Rebuild real captured page-ACKs. This is what pins down the two things
+     * the prose spec got wrong: the payload begins with the usual nonce (so the
+     * echoed page seq is at offset 6, not 4), and the frame's own SEQ is the
+     * phone's shared counter rather than the echoed page seq.
+     */
+    private static void testPageAckAgainstCapture() {
+        section("page ACK 00:7E rebuilt from captured frames");
+        // seq, nonce, ackedCmdHi, ackedCmdLo, pageSeq, expected hex
+        Object[][] cases = {
+            {0x0d, 0x5f49, 0x01, 0x01, 0x03, "005e55d80b6401640d0001007e1600495f02010100030000000000"},
+            {0x13, 0xdc10, 0x04, 0x01, 0x07, "00a2bae3c4640164130001007e160010dc02040100070000000000"},
+            {0x17, 0x86e9, 0x02, 0x01, 0x09, "002c006c61640164170001007e1600e98602020100090000000000"},
+            {0x23, 0x634c, 0x06, 0x01, 0x13, "00b96c8823640164230001007e16004c6302060100130000000000"},
+            {0x25, 0x46f2, 0x05, 0x01, 0x14, "00474ee8b8640164250001007e1600f24602050100140000000000"},
+            {0x14, 0x7bc3, 0x05, 0x01, 0x3b, "00f3a5a917640164140001007e1600c37b020501003b0000000000"},
+        };
+        for (Object[] c : cases) {
+            byte[] built = RingProtocol.buildPageAck(
+                (Integer) c[0], (Integer) c[1], (Integer) c[2], (Integer) c[3], (Integer) c[4]);
+            expectHex("ack for cmd " + hex2((Integer) c[2]) + ":" + hex2((Integer) c[3])
+                + " page seq " + hex2((Integer) c[4]), (String) c[5], built);
+        }
+
+        RingProtocol.Frame f = RingProtocol.parse(RingProtocol.buildPageAck(0x0d, 0x5f49, 0x01, 0x01, 0x03));
+        expect("ack rides the DEVICE channel", f.chan == RingProtocol.CHAN_DEVICE);
+        expect("ack kind is ACK", f.kind == RingProtocol.KIND_ACK);
+        expect("ack command is 00:7e", f.cmdHi == 0x00 && f.cmdLo == 0x7e);
+        expect("ack header seq differs from echoed page seq", f.seq != (f.payload[6] & 0xff));
+        expect("echoed page seq is at payload[6]", (f.payload[6] & 0xff) == 0x03);
+    }
+
+    private static void testParseRejectsGarbage() {
+        section("parser rejects non-frames");
+        expect("null", RingProtocol.parse(null) == null);
+        expect("too short", RingProtocol.parse(new byte[8]) == null);
+        expect("no magic", RingProtocol.parse(new byte[20]) == null);
+        // A 3-byte ring gesture frame must not look like a header.
+        expect("gesture frame is not a header",
+            !RingProtocol.looksLikeHeader(new byte[] {(byte) 0xff, 0x04, 0x01}));
+        // A frame whose PLEN disagrees with its actual length is rejected.
+        byte[] frame = RingProtocol.buildHealthRequest(RingProtocol.CMD_HI_HRV, 1, 0);
+        byte[] truncated = Arrays.copyOf(frame, frame.length - 1);
+        expect("length/PLEN mismatch rejected", RingProtocol.parse(truncated) == null);
+    }
+
+    /**
+     * Fragmentation, reproducing the shape the capture actually shows: an
+     * oversized frame split into a 244-byte FLAG=0x01 head and a headerless
+     * continuation, with an unrelated complete frame arriving in between.
+     */
+    private static void testFragmentReassembly() {
+        section("fragment reassembly");
+        // Build a 252-byte steps-shaped frame: 15 header + 237 payload.
+        byte[] payload = new byte[237];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i * 7 + 3);
+        }
+        byte[] whole = RingProtocol.buildFrame(
+            RingProtocol.CHAN_HEALTH, RingProtocol.KIND_DATA,
+            RingProtocol.CMD_HI_STEPS, RingProtocol.CMD_LO_HEALTH, 0x15, payload);
+        expect("test frame is 252 bytes", whole.length == 252);
+
+        byte[] head = Arrays.copyOf(whole, 244);
+        head[0] = (byte) RingProtocol.FLAG_FRAGMENTED;
+        byte[] continuation = new byte[RingProtocol.CONTINUATION_PREFIX_LEN + (whole.length - 244)];
+        System.arraycopy(whole, 244, continuation, RingProtocol.CONTINUATION_PREFIX_LEN, whole.length - 244);
+        expect("continuation is 5 + remaining bytes", continuation.length == 13);
+
+        byte[] interleaved = RingProtocol.buildFrame(
+            RingProtocol.CHAN_DEVICE, RingProtocol.KIND_DATA, 0x00, 0x01, 0x16, new byte[9]);
+
+        RingProtocol.Reassembler reassembler = new RingProtocol.Reassembler();
+
+        RingProtocol.Intake first = reassembler.accept(head);
+        expect("head consumed", first.consumed && first.frame == null);
+        expect("fragment outstanding", reassembler.hasPending());
+
+        RingProtocol.Intake middle = reassembler.accept(interleaved);
+        expect("interleaved frame still parses while a fragment is pending",
+            middle.consumed && middle.frame != null && middle.frame.crcOk);
+        expect("fragment survives the interleaved frame", reassembler.hasPending());
+
+        RingProtocol.Intake done = reassembler.accept(continuation);
+        expect("continuation completes the frame", done.consumed && done.frame != null);
+        expect("reassembled frame passes CRC", done.frame.crcOk);
+        expect("reassembled bytes are exact",
+            Arrays.equals(done.frame.raw, headJoined(head, whole)));
+        expect("no fragment left outstanding", !reassembler.hasPending());
+        expect("reassembled payload is intact", Arrays.equals(done.frame.payload, payload));
+
+        // Non-protocol traffic must pass straight through untouched.
+        RingProtocol.Intake gesture = reassembler.accept(new byte[] {(byte) 0xff, 0x04, 0x01});
+        expect("gesture frame is not consumed", !gesture.consumed);
+    }
+
+    private static byte[] headJoined(byte[] head, byte[] whole) {
+        byte[] expected = whole.clone();
+        expected[0] = head[0];
+        return expected;
+    }
+
+    // ------------------------------------------------------------------
+    // Synthetic record bodies, built directly from the spec's field layout.
+    // ------------------------------------------------------------------
+
+    private static void testHourlyDecode() {
+        section("hourly decode (heart rate W=1, HRV W=2, backlog page)");
+
+        // Anchored heart-rate page, W=1, three groups.
+        long anchor = 1788926400L; // 2026-09-09 00:00 local, the capture's anchor
+        int[][] groups = {{0, 61, 88, 55}, {1, 58, 71, 52}, {2, 63, 90, 57}};
+        byte[] body = hourlyBody(3, anchor, 12345L, 64, 1, groups);
+        RingProtocol.Frame frame = dataFrame(RingProtocol.CMD_HI_HEART_RATE, body);
+        RingProtocol.HourlyRecord hr = RingProtocol.decodeHourly(frame, 0L);
+        expect("HR decodes", hr != null);
+        expect("HR width resolved to 1", hr.valueWidth == 1);
+        expect("HR group count", hr.groups.length == 3);
+        expect("HR anchor", hr.anchorUnixSeconds == anchor);
+        expect("HR not backlog", !hr.isBacklog());
+        expect("HR current", hr.current == 64);
+        boolean values = true;
+        for (int i = 0; i < groups.length; i++) {
+            RingProtocol.HourlyGroup g = hr.groups[i];
+            values &= g.hourIndex == groups[i][0] && g.avg == groups[i][1]
+                && g.max == groups[i][2] && g.min == groups[i][3]
+                && g.unixSeconds == anchor + groups[i][0] * 3600L;
+        }
+        expect("HR values and hour timestamps round-trip", values);
+
+        // HRV uses two-byte values; the width must be resolved, not assumed.
+        int[][] hrvGroups = {{8, 300, 420, 210}, {9, 275, 380, 190}, {10, 512, 640, 400}};
+        byte[] hrvBody = hourlyBody(3, anchor, 22222L, 333, 2, hrvGroups);
+        RingProtocol.HourlyRecord hrv =
+            RingProtocol.decodeHourly(dataFrame(RingProtocol.CMD_HI_HRV, hrvBody), 0L);
+        expect("HRV decodes", hrv != null);
+        expect("HRV width resolved to 2", hrv.valueWidth == 2);
+        expect("HRV current", hrv.current == 333);
+        expect("HRV holds values above 255", hrv.groups[2].max == 640);
+
+        // Backlog page: anchor absent. The hour index must survive; the absolute
+        // time must NOT be invented.
+        byte[] backlogBody = hourlyBody(3, RingProtocol.UNKNOWN_TIME, 77777L, 60, 1, groups);
+        RingProtocol.HourlyRecord backlog =
+            RingProtocol.decodeHourly(dataFrame(RingProtocol.CMD_HI_HEART_RATE, backlogBody), 0L);
+        expect("backlog decodes", backlog != null);
+        expect("backlog flagged", backlog.isBacklog());
+        expect("backlog anchor unknown", backlog.anchorUnixSeconds == RingProtocol.UNKNOWN_TIME);
+        boolean noInventedTime = true;
+        for (RingProtocol.HourlyGroup g : backlog.groups) {
+            noInventedTime &= g.unixSeconds == RingProtocol.UNKNOWN_TIME;
+        }
+        expect("backlog groups carry no invented absolute time", noInventedTime);
+        expect("backlog keeps raw hour indices",
+            backlog.groups[0].hourIndex == 0 && backlog.groups[2].hourIndex == 2);
+        expect("backlog still decodes values", backlog.groups[1].avg == 58);
+    }
+
+    private static void testStepsDecode() {
+        section("steps decode");
+        long anchor = 1788926400L;
+        int[][] buckets = {{0, 120, 4, 16}, {3, 0, 0, 12}, {130, 45, 2, 14}};
+        byte[] body = stepsBody(anchor, buckets);
+        RingProtocol.StepsRecord steps =
+            RingProtocol.decodeSteps(dataFrame(RingProtocol.CMD_HI_STEPS, body), 0L);
+        expect("steps decode", steps != null);
+        expect("bucket count", steps.buckets.length == 3);
+        expect("total steps", steps.totalSteps() == 165);
+        expect("raw index preserved, including the 130+ jump",
+            steps.buckets[2].index == 130);
+        expect("v2/v3 kept as unconfirmed calorie-shaped fields",
+            steps.buckets[0].calorieLike2 == 4 && steps.buckets[0].calorieLike3 == 16);
+        expect("steps anchor", steps.anchorUnixSeconds == anchor);
+        // Length must be exact: a truncated body is a decode failure, not a guess.
+        byte[] shortBody = Arrays.copyOf(body, body.length - 1);
+        expect("truncated steps body rejected",
+            RingProtocol.decodeSteps(dataFrame(RingProtocol.CMD_HI_STEPS, shortBody), 0L) == null);
+    }
+
+    private static void testSleepDecodeAndIdentities() {
+        section("sleep decode + the spec's arithmetic identities");
+        // segments: (stage, halfMinutes). Stage sums: 0->10, 1->20, 2->70, 3->25.
+        int[][] segments = {{0, 4}, {1, 20}, {2, 40}, {0, 6}, {2, 30}, {3, 25}};
+        int totalHalfMinutes = 125;
+        int seconds = totalHalfMinutes * 30;   // 3750
+        int wake = 10 * 30;                    // 300, stage 0
+        int rem = 20 * 30;                     // 600, stage 1
+        int light = 70 * 30;                   // 2100, stage 2
+        int deep = 25 * 30;                    // 750, stage 3
+        int total = seconds - wake;            // 3450
+        long start = 100000L;
+        long end = start + seconds;
+
+        byte[] body = sleepBody(1, start, end, total, wake, rem, light, deep, segments);
+        RingProtocol.SleepRecord sleep =
+            RingProtocol.decodeSleep(dataFrame(RingProtocol.CMD_HI_SLEEP, body), 0L);
+        expect("sleep decodes", sleep != null);
+        expect("real record", sleep.isRealRecord());
+        expect("segment count", sleep.segments.length == segments.length);
+        expect("segment stages and durations round-trip",
+            sleep.segments[2].stage == 2 && sleep.segments[2].halfMinutes == 40);
+
+        expect("identity: sum(half_minutes) x 30 == total_time + wake_time",
+            sleep.totalHalfMinutes() * 30 == sleep.totalTime + sleep.wakeTime);
+        expect("identity: sum(half_minutes) x 30 == end_ts - start_ts",
+            sleep.totalHalfMinutes() * 30 == (int) (sleep.endTs - sleep.startTs));
+        expect("identity: per-stage sums match the four stage totals",
+            sleep.halfMinutesForStage(0) * 30 == wake
+                && sleep.halfMinutesForStage(1) * 30 == rem
+                && sleep.halfMinutesForStage(2) * 30 == light
+                && sleep.halfMinutesForStage(3) * 30 == deep);
+        expect("identitiesHold() agrees", sleep.identitiesHold());
+
+        expect("uncracked 6-byte field stored raw, not interpreted",
+            sleep.unknownPrefix.length == 6);
+        expect("relative timestamps kept as sent",
+            sleep.startTs == start && sleep.endTs == end);
+
+        // The empty end-of-list marker must decode without inventing a session.
+        byte[] marker = new byte[] {0x11, 0x22, 0x02};
+        RingProtocol.SleepRecord empty =
+            RingProtocol.decodeSleep(dataFrame(RingProtocol.CMD_HI_SLEEP, marker), 0L);
+        expect("RECSTATE=2 marker decodes", empty != null && !empty.isRealRecord());
+        expect("marker has no segments", empty.segments.length == 0);
+
+        // A declared segment count that does not fill the body is a parse failure.
+        byte[] broken = body.clone();
+        broken[32] = (byte) (segments.length + 1);
+        expect("segment-count mismatch rejected",
+            RingProtocol.decodeSleep(dataFrame(RingProtocol.CMD_HI_SLEEP, broken), 0L) == null);
+    }
+
+    // ------------------------------------------------------------------
+    // Synthetic body builders (mirror the spec layout, used only by the tests)
+    // ------------------------------------------------------------------
+
+    private static byte[] hourlyBody(int count, long anchor, long tag, int current,
+                                     int width, int[][] groups) {
+        byte[] body = new byte[13 + width + count * (1 + 3 * width) + 4];
+        body[0] = 0x11;
+        body[1] = 0x22;
+        body[2] = (byte) count;
+        writeAnchor(body, anchor);
+        putLe(body, 9, tag, 4);
+        putLe(body, 13, current, width);
+        int offset = 13 + width;
+        for (int[] g : groups) {
+            body[offset++] = (byte) g[0];
+            putLe(body, offset, g[1], width);
+            offset += width;
+            putLe(body, offset, g[2], width);
+            offset += width;
+            putLe(body, offset, g[3], width);
+            offset += width;
+        }
+        putFooter(body);
+        return body;
+    }
+
+    private static byte[] stepsBody(long anchor, int[][] buckets) {
+        byte[] body = new byte[9 + buckets.length * 7 + 4];
+        body[0] = 0x33;
+        body[1] = 0x44;
+        body[2] = (byte) buckets.length;
+        writeAnchor(body, anchor);
+        int offset = 9;
+        for (int[] b : buckets) {
+            body[offset] = (byte) b[0];
+            putLe(body, offset + 1, b[1], 2);
+            putLe(body, offset + 3, b[2], 2);
+            putLe(body, offset + 5, b[3], 2);
+            offset += 7;
+        }
+        putFooter(body);
+        return body;
+    }
+
+    private static byte[] sleepBody(int recordState, long start, long end, int total, int wake,
+                                    int rem, int light, int deep, int[][] segments) {
+        byte[] body = new byte[34 + segments.length * 3 + 4];
+        body[0] = 0x55;
+        body[1] = 0x66;
+        body[2] = (byte) recordState;
+        for (int i = 3; i < 9; i++) {
+            body[i] = (byte) (0xA0 + i);       // the uncracked 6-byte field
+        }
+        putLe(body, 9, 90210L, 4);             // the uncracked u32 tag
+        body[13] = 0x00;
+        putLe(body, 14, start, 4);
+        putLe(body, 18, end, 4);
+        putLe(body, 22, total, 2);
+        putLe(body, 24, wake, 2);
+        putLe(body, 26, rem, 2);
+        putLe(body, 28, light, 2);
+        putLe(body, 30, deep, 2);
+        body[32] = (byte) segments.length;
+        body[33] = 0x00;
+        int offset = 34;
+        for (int[] s : segments) {
+            body[offset] = (byte) s[0];
+            putLe(body, offset + 1, s[1], 2);
+            offset += 3;
+        }
+        putFooter(body);
+        return body;
+    }
+
+    private static void writeAnchor(byte[] body, long anchor) {
+        if (anchor == RingProtocol.UNKNOWN_TIME) {
+            return;                             // six zero bytes = backlog page
+        }
+        body[3] = 0x10;
+        body[4] = (byte) 0xFF;
+        putLe(body, 5, anchor, 4);
+    }
+
+    private static void putFooter(byte[] body) {
+        int offset = body.length - 4;
+        body[offset] = (byte) 0x94;
+        body[offset + 1] = 0x33;
+        body[offset + 2] = 0x01;
+        body[offset + 3] = 0x00;
+    }
+
+    private static void putLe(byte[] out, int offset, long value, int width) {
+        for (int i = 0; i < width; i++) {
+            out[offset + i] = (byte) ((value >>> (8 * i)) & 0xff);
+        }
+    }
+
+    private static RingProtocol.Frame dataFrame(int cmdHi, byte[] body) {
+        byte[] frame = RingProtocol.buildFrame(
+            RingProtocol.CHAN_HEALTH, RingProtocol.KIND_DATA, cmdHi,
+            RingProtocol.CMD_LO_HEALTH, 0x20, body);
+        return RingProtocol.parse(frame);
+    }
+
+    // ------------------------------------------------------------------
+
+    private static void section(String name) {
+        System.out.println();
+        System.out.println("-- " + name);
+    }
+
+    private static void expect(String what, boolean ok) {
+        checks++;
+        if (!ok) {
+            failures++;
+        }
+        System.out.println("   " + (ok ? "ok  " : "FAIL") + "  " + what);
+    }
+
+    private static void expectHex(String what, String expectedHex, byte[] actual) {
+        String actualHex = RingProtocol.hex(actual);
+        boolean ok = expectedHex.equals(actualHex);
+        checks++;
+        if (!ok) {
+            failures++;
+            System.out.println("   FAIL  " + what);
+            System.out.println("         expected " + expectedHex);
+            System.out.println("         actual   " + actualHex);
+            return;
+        }
+        System.out.println("   ok    " + what + "  " + actualHex);
+    }
+
+    private static String hex2(int value) {
+        return String.format(java.util.Locale.US, "%02x", value & 0xff);
+    }
+}

--- a/tests/health-revisions.test.cjs
+++ b/tests/health-revisions.test.cjs
@@ -1,0 +1,162 @@
+// The 2026-09-10 design revisions, pinned where getting them wrong would be
+// silent.
+//
+// These are not tests of "does it draw" - a chart's appearance is checked by
+// rendering it (tools/health-preview.cjs writes a PNG of every surface without
+// an emulator). What is worth a test here is the handful of places where the
+// revision put a SPECIFIC rule in the code that a later reader would plausibly
+// undo:
+//
+//   1. The two sleep stage orders, which differ ON PURPOSE and therefore look
+//      exactly like a typo to anyone who meets one without the other.
+//   2. The nightly sleep series, which the diverging chart plots - a gap has to
+//      stay at its own position or every later night shifts a column.
+//   3. The stat rows, where "Buckets" was removed because it was an
+//      implementation detail on screen.
+//
+// Everything runs on generated fixtures. No real health data is read.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildFixtures } = require("../.test-build/app/health/health-fixtures.js");
+const {
+  dailySummary,
+  sleepNights,
+  sleepSummary,
+  stageSeconds,
+} = require("../.test-build/app/health/health-derive.js");
+const {
+  SLEEP_LANE_ORDER,
+  SLEEP_STACK_ORDER,
+  rangeAverageText,
+} = require("../.test-build/app/health/health-chart.js");
+const { GLANCE_PAGES } = require("../.test-build/app/health/health-glance.js");
+const { startOfLocalDay, DAY_MS, SAMPLE_METRICS } = require("../.test-build/app/health/health-types.js");
+
+test("the two sleep stage orders are stated in opposite directions but agree on screen", () => {
+  // Week/month/quarter: stacked upward from zero, deep at the bottom.
+  assert.deepEqual([...SLEEP_STACK_ORDER], ["deep", "rem", "light"]);
+  // One night: lanes listed downward, awake at the top.
+  assert.deepEqual([...SLEEP_LANE_ORDER], ["wake", "light", "rem", "deep"]);
+
+  // The point worth pinning. The two orders were given in opposite directions
+  // (one bottom-to-top, one top-to-bottom) and therefore READ as contradictory,
+  // which is why the brief called the difference out as deliberate. Resolve
+  // both to the same direction and the three sleep stages land in the SAME
+  // vertical order: light highest, deep lowest. The only real difference is
+  // where awake goes - a lane above the others, or a bar below the zero line.
+  const stackTopToBottom = [...SLEEP_STACK_ORDER].reverse();
+  const lanesTopToBottomWithoutWake = SLEEP_LANE_ORDER.filter((stage) => stage !== "wake");
+  assert.deepEqual(
+    stackTopToBottom,
+    [...lanesTopToBottomWithoutWake],
+    "deep sits at the bottom in both views - do not 'fix' one to disagree with the other",
+  );
+
+  // Awake is in the lanes and NOT in the upward stack - it diverges downward.
+  assert.ok(!SLEEP_STACK_ORDER.includes("wake"));
+  assert.ok(SLEEP_LANE_ORDER.includes("wake"));
+});
+
+test("the nightly sleep series keeps gaps in position", () => {
+  const now = Date.now();
+  const today = startOfLocalDay(now);
+  const startMs = today - 6 * DAY_MS;
+  const { sleep } = buildFixtures({ days: 7, nowMs: now });
+
+  const all = sleepNights(sleep, startMs, today + DAY_MS);
+  assert.equal(all.length, 7, "one entry per day in the window, filled or not");
+
+  // Drop the middle night and check the later ones do not slide left.
+  const middleDay = all[3].startMs;
+  const thinned = sleep.filter((session) => session.dayStartMs !== middleDay);
+  const withGap = sleepNights(thinned, startMs, today + DAY_MS);
+  assert.equal(withGap.length, 7);
+  assert.equal(withGap[3].hasData, false, "the removed night is a gap, not a shift");
+  assert.equal(withGap[3].startMs, middleDay);
+  assert.deepEqual(
+    withGap.map((night) => night.startMs),
+    all.map((night) => night.startMs),
+    "every night keeps its own day on the axis",
+  );
+});
+
+test("two sessions on one day are summed, not deduped to the longest", () => {
+  const today = startOfLocalDay(Date.now());
+  const night = (totalSec, wakeSec) => ({
+    dayStartMs: today,
+    startMs: today,
+    endMs: today,
+    totalSec,
+    wakeSec,
+    remSec: totalSec * 0.2,
+    lightSec: totalSec * 0.6,
+    deepSec: totalSec * 0.2,
+    segments: [],
+    timeResolved: true,
+  });
+  const nights = sleepNights([night(3600, 300), night(1800, 60)], today, today + DAY_MS);
+  assert.equal(nights.length, 1);
+  assert.equal(nights[0].wakeSec, 360, "a nap's wake time counts too");
+  assert.ok(
+    Math.abs(nights[0].lightSec - (3600 + 1800) * 0.6) < 1e-6,
+    "stage totals add across both sessions",
+  );
+});
+
+test("a stage's lane duration comes from the named totals", () => {
+  const now = Date.now();
+  const { sleep } = buildFixtures({ days: 2, nowMs: now });
+  const summary = sleepSummary(sleep[0]);
+  // The four lanes must account for the whole time in bed, which is exactly
+  // the property that does NOT depend on the raw stage-id mapping.
+  const summed = SLEEP_LANE_ORDER.reduce(
+    (total, stage) => total + stageSeconds(stage, summary),
+    0,
+  );
+  assert.ok(
+    Math.abs(summed - (summary.totalSec + summary.wakeSec)) < 1,
+    `lanes should sum to time in bed, got ${summed}`,
+  );
+  assert.equal(stageSeconds("wake", summary), summary.wakeSec);
+});
+
+test("the glance line reads as a range and an average", () => {
+  assert.equal(
+    rangeAverageText({ min: 60, max: 98, avg: 72.6, hasData: true }, "bpm"),
+    "60-98 bpm, avg 73",
+  );
+  assert.equal(
+    rangeAverageText({ min: 0, max: 0, avg: 0, hasData: false }, "bpm"),
+    "--",
+    "no data shows a dash, never a zero",
+  );
+  // ASCII hyphen only: Terminus has no en dash and would render the default
+  // char, putting a "?" in the middle of the number.
+  const text = rangeAverageText({ min: 40, max: 62, avg: 51, hasData: true }, "ms");
+  for (const char of text) {
+    assert.ok(char.codePointAt(0) < 128, `"${char}" is outside ASCII`);
+  }
+});
+
+test("HRV reached the daily summary", () => {
+  const now = Date.now();
+  const today = startOfLocalDay(now);
+  const { samples, sleep } = buildFixtures({ days: 2, nowMs: now });
+  const summary = dailySummary(samples, sleep, today);
+  assert.ok(summary.hrv, "HRV is on the glance now - Chris revised the spec");
+  assert.ok(summary.hrv.hasData);
+  assert.ok(summary.hrv.max >= summary.hrv.min);
+});
+
+test("the glasses cursor walks the summary, every parameter, then sleep", () => {
+  assert.equal(GLANCE_PAGES[0].kind, "overview", "the glance is where it opens");
+  assert.equal(GLANCE_PAGES[GLANCE_PAGES.length - 1].kind, "sleep");
+  const walked = GLANCE_PAGES.filter((page) => page.kind === "metric").map((page) => page.metric);
+  assert.deepEqual(
+    [...walked].sort(),
+    [...SAMPLE_METRICS].sort(),
+    "every measured parameter is reachable by scrolling",
+  );
+});

--- a/tests/health.test.cjs
+++ b/tests/health.test.cjs
@@ -1,0 +1,427 @@
+// The health feature's logic, pinned where getting it wrong would be silent.
+//
+// The three things worth a test here are not the arithmetic - they are the
+// places where a bug would quietly produce a plausible wrong answer:
+//
+//   1. The STORE's durability contract. A health record may be the only copy
+//      that will ever exist (the ring appears to discard backlog it thinks it
+//      delivered), so "an append never rewrites a file that already holds
+//      records" and "a re-sync of the same hour corrects rather than
+//      duplicates" are the properties the whole feature rests on.
+//   2. The INGEST rules that decline to guess - an unanchored hourly page is
+//      dropped, and step buckets do not get invented timestamps.
+//   3. SLEEP, where the percentages must come from the named totals (which
+//      need no stage-id mapping) while only the hypnogram depends on the ids.
+//
+// Everything runs on generated fixtures. No real health data is read.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { HealthStore } = require("../.test-build/app/health/health-store.js");
+const { buildFixtures } = require("../.test-build/app/health/health-fixtures.js");
+const {
+  dailySummary,
+  sleepSummary,
+  hypnogram,
+  rollupSeries,
+  bandIsMeaningful,
+  formatDuration,
+} = require("../.test-build/app/health/health-derive.js");
+const { convertRecords, sleepIdentityHolds } = require("../.test-build/app/health/health-ingest.js");
+const {
+  STAGE_NAME_BY_ID,
+  STAGE_MAPPING_CONFIRMED,
+  stageNameForId,
+} = require("../.test-build/app/health/sleep-stages.js");
+const {
+  startOfLocalDay,
+  DAY_MS,
+  HOUR_MS,
+  TEN_MINUTES_MS,
+} = require("../.test-build/app/health/health-types.js");
+
+/** An in-memory backend that also records how each file was touched. */
+function memoryBackend() {
+  const files = new Map();
+  const ops = [];
+  return {
+    ops,
+    files,
+    exists: (name) => files.has(name),
+    read: (name) => files.get(name) ?? null,
+    append(name, text) {
+      ops.push({ op: "append", name });
+      files.set(name, (files.get(name) ?? "") + text);
+    },
+    write(name, text) {
+      ops.push({ op: "write", name });
+      files.set(name, text);
+    },
+    list: () => [...files.keys()],
+  };
+}
+
+const HOUR = 3600000;
+
+function sample(metric, startMs, min, max, avg, total) {
+  return { metric, startMs, spanMs: HOUR, min, max, avg, total: total ?? avg };
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+
+test("a stored sample survives a fresh store over the same files", () => {
+  const backend = memoryBackend();
+  const first = new HealthStore(backend);
+  const start = startOfLocalDay(Date.now());
+  first.ingestSamples([sample("heartRate", start, 55, 90, 70)]);
+
+  const second = new HealthStore(backend);
+  const held = second.samplesInRange(start, start + DAY_MS);
+  assert.equal(held.length, 1);
+  assert.equal(held[0].avg, 70);
+});
+
+test("a sample file is only ever appended to, never rewritten", () => {
+  const backend = memoryBackend();
+  const store = new HealthStore(backend);
+  const start = startOfLocalDay(Date.now());
+  for (let hour = 0; hour < 6; hour += 1) {
+    store.ingestSamples([sample("heartRate", start + hour * HOUR, 50 + hour, 90, 70 + hour)]);
+  }
+  const sampleWrites = backend.ops.filter(
+    (entry) => entry.op === "write" && entry.name.startsWith("samples-"),
+  );
+  // The rollup cache is rewritten freely - it is derived. The shards are not.
+  assert.equal(sampleWrites.length, 0);
+  assert.ok(backend.ops.some((entry) => entry.op === "append"));
+});
+
+test("re-storing an unchanged bucket writes nothing; a changed one corrects it", () => {
+  const backend = memoryBackend();
+  const store = new HealthStore(backend);
+  const start = startOfLocalDay(Date.now());
+
+  assert.equal(store.ingestSamples([sample("heartRate", start, 55, 90, 70)]), 1);
+  // The live poller re-reads the same capped list every 30 minutes; a no-op
+  // here is what stops that appending a duplicate line forever.
+  assert.equal(store.ingestSamples([sample("heartRate", start, 55, 90, 70)]), 0);
+  // The current hour genuinely changes as it fills up. Later line wins.
+  assert.equal(store.ingestSamples([sample("heartRate", start, 55, 104, 74)]), 1);
+
+  const reloaded = new HealthStore(backend);
+  const held = reloaded.samplesInRange(start, start + DAY_MS);
+  assert.equal(held.length, 1);
+  assert.equal(held[0].max, 104);
+});
+
+test("a corrupt rollup cache is rebuilt from the shards rather than trusted", () => {
+  const backend = memoryBackend();
+  const store = new HealthStore(backend);
+  const start = startOfLocalDay(Date.now());
+  store.ingestSamples([sample("heartRate", start, 55, 90, 70), sample("heartRate", start + HOUR, 60, 100, 80)]);
+
+  backend.files.set("rollups.json", "{ not json");
+  const recovered = new HealthStore(backend);
+  const rollups = recovered.dailyRollups("heartRate", start, start + DAY_MS);
+  const day = rollups.get(start);
+  assert.ok(day, "the day should be recovered from the raw shards");
+  assert.equal(day.min, 55);
+  assert.equal(day.max, 100);
+  assert.equal(day.count, 2);
+});
+
+test("a single unreadable line does not cost the rest of the file", () => {
+  const backend = memoryBackend();
+  const store = new HealthStore(backend);
+  const start = startOfLocalDay(Date.now());
+  store.ingestSamples([sample("heartRate", start, 55, 90, 70)]);
+  const name = [...backend.files.keys()].find((key) => key.startsWith("samples-"));
+  backend.files.set(name, `${backend.files.get(name)}{ truncated\n`);
+  store.ingestSamples([sample("heartRate", start + HOUR, 60, 100, 80)]);
+
+  const reloaded = new HealthStore(backend);
+  assert.equal(reloaded.samplesInRange(start, start + DAY_MS).length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Ingest: the rules that decline to guess
+
+test("an unanchored hourly page is dropped, not dated", () => {
+  const result = convertRecords([
+    {
+      kind: "hourly",
+      metric: "heartRate",
+      anchorMs: null,
+      groups: [{ hourIndex: 0, avg: 70, max: 90, min: 55 }],
+    },
+  ]);
+  assert.equal(result.samples.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.match(result.skipped[0].why, /anchor/);
+});
+
+test("an anchored hourly page dates each group from the anchor", () => {
+  const anchor = startOfLocalDay(Date.now());
+  const result = convertRecords([
+    {
+      kind: "hourly",
+      metric: "hrv",
+      anchorMs: anchor,
+      groups: [
+        { hourIndex: 0, avg: 40, max: 40, min: 40 },
+        { hourIndex: 5, avg: 52, max: 55, min: 50 },
+      ],
+    },
+  ]);
+  assert.equal(result.samples.length, 2);
+  assert.equal(result.samples[0].startMs, anchor);
+  assert.equal(result.samples[1].startMs, anchor + 5 * HOUR_MS);
+});
+
+// The index is cracked (2026-09-12): bucket i starts at anchor + i * 10 minutes.
+// This test previously asserted the opposite - one day-span total, buckets
+// deliberately discarded - which was the honest call while the index was only
+// trusted as an identity. It is now the placement contract.
+test("steps place each bucket at anchor + index * ten minutes", () => {
+  const anchor = startOfLocalDay(Date.now());
+  const result = convertRecords([
+    {
+      kind: "steps",
+      anchorMs: anchor,
+      buckets: [
+        { index: 0, steps: 100, activeCalories: 4, totalCalories: 15 },
+        { index: 130, steps: 260, activeCalories: 9, totalCalories: 21 },
+      ],
+    },
+  ]);
+  const steps = result.samples.filter((entry) => entry.metric === "steps");
+  assert.equal(steps.length, 2, "one sample per bucket, not one day total");
+  assert.equal(steps[0].startMs, anchor);
+  assert.equal(steps[0].total, 100);
+  assert.equal(steps[0].spanMs, TEN_MINUTES_MS);
+  assert.equal(steps[1].startMs, anchor + 130 * TEN_MINUTES_MS);
+  assert.equal(steps[1].total, 260);
+
+  // The day total is now `sum` and ONLY `sum` - `max`/`avg` are per-bucket.
+  // Every reader was checked against this on 2026-09-12.
+  assert.equal(
+    steps.reduce((acc, entry) => acc + entry.total, 0),
+    360,
+  );
+
+  const calories = result.samples.filter((entry) => entry.metric === "calories");
+  assert.equal(calories.length, 2);
+  assert.equal(calories[1].startMs, anchor + 130 * TEN_MINUTES_MS);
+  assert.equal(calories[1].total, 21);
+
+  // Nothing is declined any more - the buckets are placed, not discarded.
+  assert.equal(result.skipped.length, 0);
+});
+
+test("a sleep session is stored with its time marked unresolved", () => {
+  const result = convertRecords([
+    {
+      kind: "sleep",
+      startTs: 90000,
+      endTs: 90000 + 21600,
+      totalSec: 20400,
+      wakeSec: 1200,
+      remSec: 3600,
+      lightSec: 12000,
+      deepSec: 4800,
+      segments: [{ stageId: 2, halfMinutes: 720 }],
+      receivedAtMs: Date.now(),
+    },
+  ]);
+  assert.equal(result.sleep.length, 1);
+  assert.equal(result.sleep[0].timeResolved, false);
+  assert.equal(result.sleep[0].dayStartMs, startOfLocalDay(Date.now()));
+});
+
+// The first real sleep record off the hardware, 2026-09-12, verbatim from
+// `files/health/sleep.jsonl` under com.faceclaw.app. It is here as a FROZEN
+// known-good: the -8h correction was derived from Chris confirming the window
+// two independent ways, and a future change that quietly makes it -4h again
+// (or 0h, which is what shipped first) should fail a test rather than wait to
+// be noticed in a chart.
+const REAL_SLEEP_RECORD = {
+  kind: "sleep",
+  startTs: 1789222861,
+  endTs: 1789233931,
+  totalSec: 10440,
+  wakeSec: 630,
+  remSec: 1620,
+  lightSec: 5880,
+  deepSec: 2940,
+  segments: [
+    { stageId: 0, halfMinutes: 21 },
+    { stageId: 2, halfMinutes: 42 },
+    { stageId: 3, halfMinutes: 36 },
+    { stageId: 2, halfMinutes: 40 },
+    { stageId: 1, halfMinutes: 36 },
+    { stageId: 2, halfMinutes: 42 },
+    { stageId: 3, halfMinutes: 62 },
+    { stageId: 2, halfMinutes: 46 },
+    { stageId: 1, halfMinutes: 18 },
+    { stageId: 2, halfMinutes: 26 },
+  ],
+  receivedAtMs: 1789234000000,
+};
+
+test("a clock correction promotes a sleep session to a real placement", () => {
+  const rawStartMs = REAL_SLEEP_RECORD.startTs * 1000;
+  // Twice the hourly ring-clock offset, computed the way health-live.ts
+  // computes it - so this says what the RULE is rather than restating a
+  // constant that would rot at the November DST change.
+  const correction = 2 * new Date(rawStartMs).getTimezoneOffset() * 60 * 1000;
+
+  const result = convertRecords([{ ...REAL_SLEEP_RECORD, clockCorrectionMs: correction }]);
+  assert.equal(result.sleep.length, 1);
+  const night = result.sleep[0];
+
+  assert.equal(night.timeResolved, true, "a corrected session is placed, not unresolved");
+  assert.equal(night.startMs, rawStartMs - correction);
+  assert.equal(night.endMs, REAL_SLEEP_RECORD.endTs * 1000 - correction);
+  // The wake-up day, not the day it happened to be received on.
+  assert.equal(night.dayStartMs, startOfLocalDay(night.endMs));
+  // The correction must move where the night sits, never how long it was.
+  assert.equal(night.endMs - night.startMs, 11070 * 1000);
+  assert.equal(night.totalSec, 10440);
+});
+
+test("the real 2026-09-12 record decodes to the window Chris confirmed", (t) => {
+  // EDT only: the known-good is a wall-clock reading and the assertion is
+  // meaningless in another zone. Skipped rather than weakened elsewhere.
+  if (new Date(REAL_SLEEP_RECORD.startTs * 1000).getTimezoneOffset() !== 240) {
+    t.skip("not EDT");
+    return;
+  }
+  const result = convertRecords([{ ...REAL_SLEEP_RECORD, clockCorrectionMs: 8 * 3600 * 1000 }]);
+  const night = result.sleep[0];
+  const local = (ms) => new Date(ms).toLocaleString("sv-SE", { timeZone: "America/New_York" });
+  assert.equal(local(night.startMs), "2026-09-12 02:21:01");
+  assert.equal(local(night.endMs), "2026-09-12 05:25:31");
+});
+
+// ---------------------------------------------------------------------------
+// Sleep
+
+test("stage percentages come from the named totals, not from the stage ids", () => {
+  const session = {
+    dayStartMs: startOfLocalDay(Date.now()),
+    startMs: 0,
+    endMs: 0,
+    totalSec: 20000,
+    wakeSec: 1000,
+    remSec: 4000,
+    lightSec: 12000,
+    deepSec: 4000,
+    // Deliberately unmappable ids: the percentages must not care.
+    segments: [{ stageId: 9, halfMinutes: 700 }],
+    timeResolved: true,
+  };
+  const summary = sleepSummary(session);
+  assert.equal(Math.round(summary.remPercent), 20);
+  assert.equal(Math.round(summary.lightPercent), 60);
+  assert.equal(Math.round(summary.deepPercent), 20);
+  // total / (total + wake) = 20000 / 21000
+  assert.equal(Math.round(summary.efficiencyPercent), 95);
+  // ...while the hypnogram, which does depend on the ids, says so.
+  assert.equal(hypnogram(session)[0].stage, null);
+});
+
+test("the stage-id mapping is the one named place, and it is the derived one", () => {
+  assert.equal(stageNameForId(0), "wake");
+  assert.equal(stageNameForId(1), "rem");
+  assert.equal(stageNameForId(2), "light");
+  assert.equal(stageNameForId(3), "deep");
+  assert.equal(stageNameForId(4), null);
+  assert.equal(Object.keys(STAGE_NAME_BY_ID).length, 4);
+  // Pinned deliberately: flipping this is the confirmation step, and it should
+  // be a decision someone makes, not something that drifts.
+  assert.equal(STAGE_MAPPING_CONFIRMED, false);
+});
+
+test("no sleep-quality composite is exposed", () => {
+  const summary = sleepSummary({
+    dayStartMs: 0, startMs: 0, endMs: 0,
+    totalSec: 20000, wakeSec: 1000, remSec: 4000, lightSec: 12000, deepSec: 4000,
+    segments: [], timeResolved: true,
+  });
+  const invented = Object.keys(summary).filter((key) => /quality|score/i.test(key));
+  assert.deepEqual(invented, []);
+});
+
+// ---------------------------------------------------------------------------
+// Series and fixtures
+
+test("a range with no data comes back as gaps at the right positions", () => {
+  const start = startOfLocalDay(Date.now());
+  const points = rollupSeries([sample("heartRate", start + 3 * HOUR, 55, 90, 70)], {
+    metric: "heartRate",
+    granularity: "hour",
+    startMs: start,
+    endMs: start + DAY_MS,
+  });
+  assert.equal(points.length, 24);
+  assert.equal(points[0].count, 0);
+  assert.equal(points[3].count, 1);
+  assert.equal(points[3].avg, 70);
+});
+
+test("the band is drawn for heart rate and dropped for a collapsed metric", () => {
+  const start = startOfLocalDay(Date.now());
+  const spread = [];
+  const flat = [];
+  for (let hour = 0; hour < 12; hour += 1) {
+    spread.push({ startMs: start + hour * HOUR, spanMs: HOUR, min: 60, max: 92, avg: 74, sum: 74, count: 1 });
+    flat.push({ startMs: start + hour * HOUR, spanMs: HOUR, min: 97, max: 97, avg: 97, sum: 97, count: 1 });
+  }
+  assert.equal(bandIsMeaningful(spread), true);
+  assert.equal(bandIsMeaningful(flat), false);
+});
+
+test("the fixtures reproduce the shapes the real export has", () => {
+  const now = Date.now();
+  const { samples, sleep } = buildFixtures({ days: 7, nowMs: now });
+
+  const hourly = samples.filter((entry) => entry.metric === "heartRate");
+  assert.ok(hourly.every((entry) => entry.spanMs === HOUR_MS), "heart rate is hourly");
+  const stepBuckets = samples.filter((entry) => entry.metric === "steps");
+  assert.ok(stepBuckets.every((entry) => entry.spanMs === 600000), "steps are ten-minute");
+
+  // Heart rate has a real spread; SpO2 mostly does not. Both were measured off
+  // the export before the generator was written.
+  const hrSpread = hourly.filter((entry) => entry.max > entry.min).length / hourly.length;
+  const spo2 = samples.filter((entry) => entry.metric === "spo2");
+  const spo2Spread = spo2.filter((entry) => entry.max > entry.min).length / spo2.length;
+  assert.ok(hrSpread > 0.9, `heart rate should nearly always have spread, got ${hrSpread}`);
+  assert.ok(spo2Spread < 0.15, `SpO2 should rarely have spread, got ${spo2Spread}`);
+
+  // Every generated night satisfies the same identity real records satisfy.
+  for (const night of sleep) {
+    assert.ok(
+      sleepIdentityHolds(night),
+      "segment run must account for exactly the time in bed",
+    );
+  }
+});
+
+test("the daily summary picks last night and today's own buckets", () => {
+  const now = Date.now();
+  const today = startOfLocalDay(now);
+  const { samples, sleep } = buildFixtures({ days: 3, nowMs: now });
+  const summary = dailySummary(samples, sleep, today);
+  assert.equal(summary.dayStartMs, today);
+  assert.ok(summary.heartRate.hasData);
+  assert.ok(summary.sleep, "there should be a night attributed to today");
+  assert.ok(summary.steps >= 0);
+});
+
+test("durations format the way the glance prints them", () => {
+  assert.equal(formatDuration(0), "--");
+  assert.equal(formatDuration(6 * 3600 + 12 * 60), "6h 12m");
+  assert.equal(formatDuration(45 * 60), "45m");
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -30,6 +30,15 @@
     "../app/apps/evenhub/containers.ts",
     "../app/apps/timer/timer-model.ts",
     "../app/apps/teleprompter/script-tracker.ts",
-    "../app/apps/nightscout/nightscout-alerts.ts"
+    "../app/apps/nightscout/nightscout-alerts.ts",
+    "../app/health/health-types.ts",
+    "../app/health/health-derive.ts",
+    "../app/health/health-store.ts",
+    "../app/health/health-ingest.ts",
+    "../app/health/health-fixtures.ts",
+    "../app/health/sleep-stages.ts",
+    "../app/health/health-chart.ts",
+    "../app/health/health-glance.ts",
+    "../app/health/health-phone-chart.ts"
   ]
 }

--- a/tools/health-preview.cjs
+++ b/tools/health-preview.cjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * Render every health surface to a PNG, under plain node, with no emulator.
+ *
+ * ## Why this exists
+ *
+ * The first pass at this feature verified its layout by building an Android
+ * AVD, booting it headless, installing the app and screenshotting it. That
+ * works, and it cost most of a three-hour dispatch to set up for a question -
+ * "does this layout look right?" - that never needed a device in the loop.
+ *
+ * Everything the health screens draw goes into a `GrayImage` through code that
+ * imports nothing from NativeScript: `health/health-chart.ts` (the primitives),
+ * `health/health-glance.ts` (the glasses pages) and
+ * `health/health-phone-chart.ts` (the phone bitmap). So this script calls the
+ * REAL drawing functions with fixture data and writes what comes back. The
+ * previews cannot drift from the app, because they are not a second
+ * implementation of it - they are the same functions the device calls.
+ *
+ * ## The one platform shim, and why it is honest
+ *
+ * `graphics/bdffont.ts` reads the bundled .bdf through
+ * `knownFolders.currentApp()`. That is the only NativeScript call anywhere
+ * under the drawing code, so it gets one stub backed by node:fs, pointed at the
+ * same `app/fonts/` files the device loads. The glyphs are the real glyphs.
+ *
+ * ⚠ FONT CAVEAT, worth knowing before reading a preview as gospel. The device's
+ * DEFAULT UI font is Roboto-Light at 14px, a TTF - and TTF rasterization on
+ * this project happens in Java (`TtfFont.load` bails unless `global.isAndroid`),
+ * so it cannot run here. Off Android the shipping code falls back to the
+ * Terminus bitmap faces, which is what these previews use. That is a real,
+ * user-selectable configuration rather than a preview-only invention, but it is
+ * not the default, and text will not be pixel-identical to a device screenshot.
+ *
+ * The layouts are written against `font.lineHeight` / `measureText` rather than
+ * fixed offsets, so what actually matters is whether they survive the font
+ * metric range. `--big` re-renders everything one bitmap size up (small 12px ->
+ * 16px, large 24px -> 32px) to check exactly that; the guaranteed small-font
+ * line-height band is 12..21 (see ui-fonts.ts), and 12 and 16 sit inside it.
+ *
+ * ## Use
+ *
+ *     npx tsc -p tests/tsconfig.json      # or: npm test
+ *     node tools/health-preview.cjs [--out DIR] [--big] [--real DIR]
+ *
+ * ## --real: the same surfaces, on data pulled off the phone
+ *
+ * `--real DIR` reads a `sleep.jsonl` (and, if present, a `samples-*.jsonl`)
+ * copied out of `files/health/` under `com.faceclaw.app` and renders the sleep
+ * surfaces from THAT instead of from fixtures. Nothing about the drawing
+ * changes - it is the same `drawGlancePage` and `renderPhoneChart` - so the
+ * question it answers is only ever "what does the real data look like in the
+ * layout we already have", never "should the layout be different".
+ *
+ * A stored session written by a pre-correction build carries
+ * `timeResolved: false` and RAW ring seconds. Those are run back through the
+ * shipping `convertRecords()` with the real clock correction, so the preview
+ * shows what the phone will store after the fix rather than a hand-placed
+ * guess. A session already marked resolved is used as-is and not corrected
+ * twice.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const Module = require("node:module");
+
+const ROOT = path.resolve(__dirname, "..");
+const APP = path.join(ROOT, "app");
+const BUILD = path.join(ROOT, ".test-build", "app");
+
+// --- the one platform shim -------------------------------------------------
+const nsCoreStub = {
+  knownFolders: {
+    currentApp: () => ({
+      getFile: (relative) => ({
+        readTextSync: () => fs.readFileSync(path.join(APP, relative), "utf8"),
+      }),
+    }),
+  },
+};
+const realLoad = Module._load;
+Module._load = function (request) {
+  if (request === "@nativescript/core") return nsCoreStub;
+  return realLoad.apply(this, arguments);
+};
+
+if (!fs.existsSync(BUILD)) {
+  console.error(`No ${path.relative(ROOT, BUILD)} - run: npx tsc -p tests/tsconfig.json`);
+  process.exit(1);
+}
+
+const { GrayImage } = require(path.join(BUILD, "graphics/image.js"));
+const { getFont } = require(path.join(BUILD, "graphics/bdffont.js"));
+const { buildFixtures } = require(path.join(BUILD, "health/health-fixtures.js"));
+const {
+  dailySummary,
+  hypnogram,
+  rollupSeries,
+  shortWeekday,
+  sleepNights,
+  sleepSummary,
+  stageSeconds,
+  formatDuration,
+} = require(path.join(BUILD, "health/health-derive.js"));
+const { drawGlancePage, GLANCE_PAGES } = require(path.join(BUILD, "health/health-glance.js"));
+const { convertRecords } = require(path.join(BUILD, "health/health-ingest.js"));
+const { HealthStore } = require(path.join(BUILD, "health/health-store.js"));
+const { renderPhoneChart } = require(path.join(BUILD, "health/health-phone-chart.js"));
+const { stageLabel } = require(path.join(BUILD, "health/sleep-stages.js"));
+const { DAY_MS, SAMPLE_METRICS, startOfLocalDay } = require(path.join(BUILD, "health/health-types.js"));
+const UPNG = require("upng-js");
+
+// --- arguments -------------------------------------------------------------
+const args = process.argv.slice(2);
+const big = args.includes("--big");
+const realIndex = args.indexOf("--real");
+const REAL_DIR = realIndex >= 0 && args[realIndex + 1] ? path.resolve(args[realIndex + 1]) : null;
+const outIndex = args.indexOf("--out");
+const OUT = path.resolve(
+  outIndex >= 0 && args[outIndex + 1] ? args[outIndex + 1] : path.join(ROOT, "preview"),
+);
+fs.mkdirSync(OUT, { recursive: true });
+
+const small = getFont(big ? "terminus16" : "terminus12");
+const large = getFont(big ? "terminus32" : "terminus24");
+const fonts = { small, large };
+
+// --- real data, when asked for ---------------------------------------------
+/**
+ * `HealthStorageBackend` over a plain directory.
+ *
+ * Reading the pulled files THROUGH the real store, rather than parsing them
+ * here, is the same rule the rest of this tool follows. The on-disk sample line
+ * is a compact seven-key shape (`{m,t,s,n,x,a,u}`) that only `health-store.ts`
+ * knows how to read; a hand-rolled parser for it in a preview script is exactly
+ * the kind of second implementation that drifts. Read-only - `append`/`write`
+ * throw rather than quietly doing nothing, so a preview can never mutate a
+ * pulled copy of real data.
+ */
+class DirBackend {
+  constructor(dir) {
+    this.dir = dir;
+  }
+  exists(name) {
+    return fs.existsSync(path.join(this.dir, name));
+  }
+  read(name) {
+    return this.exists(name) ? fs.readFileSync(path.join(this.dir, name), "utf8") : null;
+  }
+  append() {
+    throw new Error("health-preview is read-only");
+  }
+  write() {
+    throw new Error("health-preview is read-only");
+  }
+  list() {
+    return fs.readdirSync(this.dir);
+  }
+}
+
+/**
+ * Put a stored session in the frame the corrected build will store it in.
+ *
+ * The correction is NOT applied here by hand - the record is turned back into
+ * the wire shape and pushed through the real `convertRecords()`, so if that
+ * function is wrong the preview is wrong in exactly the same way the phone is,
+ * which is the only useful behaviour for a check like this.
+ */
+function resolveStoredSleep(stored) {
+  if (stored.timeResolved) return stored;
+  const startTs = Math.round(stored.startMs / 1000);
+  const endTs = Math.round(stored.endMs / 1000);
+  const correction = 2 * new Date(stored.startMs).getTimezoneOffset() * 60 * 1000;
+  const { sleep } = convertRecords([
+    {
+      kind: "sleep",
+      startTs,
+      endTs,
+      totalSec: stored.totalSec,
+      wakeSec: stored.wakeSec,
+      remSec: stored.remSec,
+      lightSec: stored.lightSec,
+      deepSec: stored.deepSec,
+      segments: stored.segments,
+      receivedAtMs: stored.startMs,
+      clockCorrectionMs: correction,
+    },
+  ]);
+  return sleep[0];
+}
+
+function loadReal(dir) {
+  const store = new HealthStore(new DirBackend(dir));
+  const sleep = store.sleepSessions().map(resolveStoredSleep);
+  if (sleep.length === 0) {
+    console.error(`No sleep sessions in ${dir}/sleep.jsonl`);
+    process.exit(1);
+  }
+  // Pin the clock to mid-afternoon of the most recent night's WAKE-UP day, so
+  // "today" is the day that night belongs to and the glance reads like a real
+  // one rather than an empty day.
+  const latest = sleep.reduce((a, b) => (b.dayStartMs > a.dayStartMs ? b : a));
+  const nowMs = latest.dayStartMs + 15 * 3600 * 1000 + 20 * 60 * 1000;
+  // A bounded window, not (0, MAX): samplesInRange walks a shard per MONTH, so
+  // an open range asks it to name a few million files and it returns nothing.
+  // A quarter back covers every view this tool renders.
+  const samples = store.samplesInRange(nowMs - 120 * DAY_MS, nowMs + DAY_MS);
+  console.log(`real data: ${sleep.length} sleep session(s), ${samples.length} samples`);
+  for (const night of sleep) {
+    console.log(
+      `  night ${new Date(night.startMs).toString()}\n` +
+        `     -> ${new Date(night.endMs).toString()}` +
+        `  total ${night.totalSec}s wake ${night.wakeSec}s` +
+        `  timeResolved=${night.timeResolved}`,
+    );
+  }
+  return { samples, sleep, nowMs };
+}
+
+// --- data ------------------------------------------------------------------
+// A fixed clock so a preview is reproducible and its date caption is stable.
+// Mid-afternoon, so "today so far" is a partial day like a real glance.
+const real = REAL_DIR ? loadReal(REAL_DIR) : null;
+const NOW = real ? real.nowMs : new Date(2026, 8, 10, 15, 20, 0).getTime();
+const TODAY = startOfLocalDay(NOW);
+const fixtures = real
+  ? { samples: real.samples, sleep: real.sleep }
+  : buildFixtures({ days: 95, nowMs: NOW, seed: 0x5eed });
+
+const todaySamples = fixtures.samples.filter(
+  (sample) => sample.startMs >= TODAY && sample.startMs < TODAY + DAY_MS,
+);
+const summary = dailySummary(todaySamples, fixtures.sleep, TODAY);
+const lastNight = fixtures.sleep.find((session) => session.dayStartMs === TODAY);
+
+const hourly = {};
+for (const metric of SAMPLE_METRICS) {
+  hourly[metric] = rollupSeries(todaySamples, {
+    metric,
+    granularity: "hour",
+    startMs: TODAY,
+    endMs: TODAY + DAY_MS,
+  });
+}
+
+const glanceData = {
+  summary,
+  hourly,
+  stageBands: lastNight ? hypnogram(lastNight) : [],
+  nowMs: NOW,
+  // The badge the glasses footer draws. It must follow the DATA, or a real
+  // render comes out stamped "Sample data" and the preview lies about the one
+  // thing it exists to show.
+  fixture: !real,
+};
+
+// --- PNG out ---------------------------------------------------------------
+const written = [];
+
+function writePng(name, image) {
+  const baked = image.withDrawsBaked();
+  const rgba = new Uint8Array(baked.width * baked.height * 4);
+  for (let i = 0; i < baked.pixels.length; i += 1) {
+    const value = baked.pixels[i];
+    rgba[i * 4] = value;
+    rgba[i * 4 + 1] = value;
+    rgba[i * 4 + 2] = value;
+    rgba[i * 4 + 3] = 255;
+  }
+  const file = path.join(OUT, `${REAL_DIR ? "real-" : ""}${name}${big ? "-big" : ""}.png`);
+  fs.writeFileSync(file, Buffer.from(UPNG.encode([rgba.buffer], baked.width, baked.height, 0)));
+
+  // A blank canvas would otherwise be a silent pass, and a page that drew
+  // nothing is exactly the failure a preview is supposed to catch.
+  let lit = 0;
+  for (const value of baked.pixels) if (value > 0) lit += 1;
+  const inkPercent = ((lit / baked.pixels.length) * 100).toFixed(1);
+  written.push({ name: path.basename(file), size: `${baked.width}x${baked.height}`, ink: `${inkPercent}%` });
+  if (lit === 0) console.error(`  !! ${file} is entirely blank`);
+}
+
+// --- the glasses: 640x480, the G2 lens ------------------------------------
+const LENS = { width: 640, height: 480 };
+GLANCE_PAGES.forEach((page, index) => {
+  const name =
+    page.kind === "overview" ? "overview" : page.kind === "sleep" ? "sleep" : page.metric;
+  const image = new GrayImage(LENS.width, LENS.height, 0);
+  drawGlancePage(image, LENS, fonts, page, glanceData);
+  writePng(`glasses-${String(index + 1).padStart(2, "0")}-${name}`, image);
+});
+
+// --- the phone -------------------------------------------------------------
+/**
+ * Two widths, both real: 411dp is the Fold 7's cover screen (the compact
+ * layout), 750dp its inner screen (expanded). Both are the numbers the first
+ * pass measured on screen in the emulator, so the previews line up with the
+ * readout in those screenshots. The chart renders at RENDER_SCALE 2 into a box
+ * of (width - 32)dp, matching health-view-model.ts.
+ */
+const RENDER_SCALE = 2;
+const PHONE_LAYOUTS = [
+  { name: "narrow", widthDp: 411, chartHeightDp: 190 },
+  { name: "wide", widthDp: 750, chartHeightDp: 380 },
+];
+
+function phoneChart(layout, name, content) {
+  const image = renderPhoneChart({
+    width: Math.round((layout.widthDp - 32) * RENDER_SCALE),
+    height: Math.round(layout.chartHeightDp * RENDER_SCALE),
+    font: small,
+    content,
+  });
+  writePng(`phone-${layout.name}-${name}`, image);
+}
+
+function metricContent(metric, granularity, days) {
+  const startMs = TODAY - (days - 1) * DAY_MS;
+  const points = rollupSeries(fixtures.samples, {
+    metric,
+    granularity,
+    startMs,
+    endMs: TODAY + DAY_MS,
+  });
+  return {
+    kind: "metric",
+    metric,
+    points,
+    mode: metric === "steps" || metric === "calories" ? "bars" : "band",
+    xLabel: (point) =>
+      granularity === "hour"
+        ? `${new Date(point.startMs).getHours()}`
+        : days <= 7
+          ? shortWeekday(point.startMs)
+          : `${new Date(point.startMs).getDate()}`,
+  };
+}
+
+function nightsContent(days) {
+  const startMs = TODAY - (days - 1) * DAY_MS;
+  return {
+    kind: "nights",
+    nights: sleepNights(fixtures.sleep, startMs, TODAY + DAY_MS),
+    xLabel: (night) =>
+      days <= 7 ? shortWeekday(night.startMs) : `${new Date(night.startMs).getDate()}`,
+  };
+}
+
+function lanesContent() {
+  const summaryOfNight = lastNight ? sleepSummary(lastNight) : null;
+  return {
+    kind: "lanes",
+    bands: lastNight ? hypnogram(lastNight) : [],
+    laneText: (stage) => ({
+      label: stageLabel(stage),
+      value: summaryOfNight ? formatDuration(stageSeconds(stage, summaryOfNight)) : "--",
+    }),
+  };
+}
+
+for (const layout of PHONE_LAYOUTS) {
+  phoneChart(layout, "hr-day", metricContent("heartRate", "hour", 1));
+  phoneChart(layout, "hr-week", metricContent("heartRate", "day", 7));
+  phoneChart(layout, "spo2-day", metricContent("spo2", "hour", 1));
+  phoneChart(layout, "steps-week", metricContent("steps", "day", 7));
+  phoneChart(layout, "sleep-day-lanes", lanesContent());
+  phoneChart(layout, "sleep-week", nightsContent(7));
+  phoneChart(layout, "sleep-month", nightsContent(30));
+  phoneChart(layout, "sleep-quarter", nightsContent(90));
+}
+
+// --- report ----------------------------------------------------------------
+console.log(`font: small lineHeight ${small.lineHeight}, large lineHeight ${large.lineHeight}`);
+console.log(`wrote ${written.length} PNGs to ${OUT}\n`);
+for (const entry of written) {
+  console.log(`  ${entry.name.padEnd(34)} ${entry.size.padEnd(10)} ink ${entry.ink}`);
+}


### PR DESCRIPTION
Implements the R1 ring's health-data sync, per your comment on #22.

This answers the open question from #22 and `notes/apps.txt` about where interpretation happens: **it happens on the ring.** Sleep arrives already classified into stages; the phone does no inference. Heart rate, HRV and SpO2 cross-checked 65/65 exactly against Even's own CSV export, and the sleep stage mapping was verified across 34 real nights.

### Two commits

1. **The protocol.** `RingProtocol.java` — 15-byte header, 2-byte command id, CRC-32C (non-reflected) over the frame body, fragment reassembly, decoders for all five record types, page ACK. Plus a self-test against captured bytes, and the `FaceclawBleCommunicator` wiring.
2. **The health layer.** On-device append-only store with deduping ingest, rollups, a per-day step-bucket ledger, sleep stage mapping, chart derivations, and a glasses glance page. 26 new tests.

### Three traps worth reading before touching this

Each cost days, and each is documented in the code because a reviewer tidying any of them would silently break the sync.

1. **The `00:08` handshake frame is the one request whose payload carries no nonce** — exactly `3f 01 01`. Measured across 46 real writes, zero exceptions: the 3-byte form is always answered, the 5-byte form never is. Prepend a nonce and the ring discards the frame, then ignores every subsequent request on that connection. This one cost two full sessions.
2. **A lost race appears to destroy backlog permanently.** The ring holds only one type's response in flight; requesting the next type before the previous type's DATA lands silently drops it, and the data does not come back. `requestRingHealth()` is response-paced rather than sleep-paced, and ACKs each page as it arrives.
3. **`HEALTH_COMMANDS` mirrors Even's own request order.** Whether the ring cares is untested; matching is the cheap way not to find out.

### On the app half

Offered as **documentation by implementation** rather than as UI you have to accept — you mentioned wanting to fold this into Glanceboard, which makes sense. The value is the executable answer to what each field means. Treat the glance page as a reference decoder and rework the presentation however suits.

**I deliberately left out our phone-UI integration.** Our fork's `phone-ui/` has diverged a long way from yours and the conflicts were all in our Exocortex-specific work, none of it relevant to you. Wiring your own phone surface to `app/health/` should be straightforward — the store and derivations are UI-agnostic.

### Honest limitations

- **Three clock frames meet in this data.** The ring's clock is deliberately set to `now + 4h` (matching what a real Even write carries), so its timestamps need correcting on read. Sleep needs `-8h`, twice the correction, confirmed against a known night. **Why the ring wants these quantities is unexplained** — the code says so rather than inventing a mechanism, because the tidy explanation was tried and measurement falsified it. Both offsets are DST-tracking but re-verification at the November change would be wise.
- **One calorie field mapping is unverified** — the decode never resolved which of two calorie-like fields is active vs total burn. Flagged at the site; swapping them is the whole fix if it reads wrong.
- **Sleep arrives in blocks, not whole nights**, and the ring will not re-deliver a block it has already sent.

### Tests

364 tests, 342 pass, 22 fail. **Those same 22 fail on clean `upstream/main` at `5bbb04a`** — I ran it as a control in an isolated worktree before claiming this. Compass strip, pinball, background hub and wire-edge tests. Not from this PR, but you may want to know your main is red.

### Two corrections to my #22 comment, both in our favour

That comment said the steps bucket index does not decode to wall-clock time, and that steps are stored at day resolution. Both are now solved: buckets are **10-minute windows counted from the record's anchor**, confirmed twice against a live ledger, and steps are a real ten-minute series.
